### PR TITLE
Fix SiteGround anti-bot challenge blocking crawls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Docker variant for Render — use this if the native Python environment is
+# missing Chromium's system libraries (errors like
+# "error while loading shared libraries: libnss3.so").
+#
+# The official Playwright image ships Chromium + all required OS deps, and
+# already sets PLAYWRIGHT_BROWSERS_PATH=/ms-playwright (do NOT override it).
+#
+# To use on Render: set the service to a Docker environment pointing at this
+# file (see the commented "Docker alternative" block in render.yaml), and drop
+# the PLAYWRIGHT_BROWSERS_PATH env var.
+FROM mcr.microsoft.com/playwright/python:v1.49.0-jammy
+
+WORKDIR /app
+
+# Install Python deps first for better layer caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install the project
+COPY . .
+RUN pip install -e .
+
+# Browsers are preinstalled in the base image; ensure Chromium is present
+RUN python -m playwright install chromium
+
+CMD ["python", "orchestrator.py"]

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -28,7 +28,10 @@ class CrawlerConfig:
     )
     excluded_paths: List[str] = field(default_factory=list)
     exclude_hidden_elements: bool = True
-    delay_before_return_html: int = 3
+    delay_before_return_html: int = 5
+    # Extra wait (seconds) on the first/root fetch so JS anti-bot challenges
+    # (e.g. SiteGround's "Robot Challenge Screen") can resolve and reload.
+    challenge_wait: int = 12
 
     # Validation parameters
     expected_chunks: int = 0  # 0 means no validation
@@ -83,10 +86,30 @@ class CrawlerConfig:
 
     # Browser configuration
     browser_type: str = "chromium"
-    headless: bool = True
-    light_mode: bool = True
-    text_mode: bool = True
+    # Launch a real Chrome channel ("chrome") rather than bundled Chromium —
+    # passes JS anti-bot challenges far more reliably. Set to "chromium" on
+    # headless servers (e.g. Render) that don't have Chrome installed.
+    browser_channel: str = "chrome"
+    headless: bool = False
+    # light_mode / text_mode strip browser features and produce a bot-like
+    # fingerprint that anti-bot challenges flag — keep them off for crawling.
+    light_mode: bool = False
+    text_mode: bool = False
     ignore_https_errors: bool = True
+    # Anti-bot / stealth. magic enables crawl4ai's evasion bundle; the other
+    # two patch navigator props and emulate human interaction.
+    magic: bool = True
+    simulate_user: bool = True
+    override_navigator: bool = True
+    # A SINGLE fixed User-Agent for the whole session. With magic=True crawl4ai
+    # otherwise generates a NEW random UA on every request, which breaks anti-bot
+    # clearance cookies (SiteGround binds clearance to the UA) and causes
+    # intermittent 403s. Keep it consistent. Override per-environment via
+    # USER_AGENT env (e.g. a Linux Chrome UA on a Linux server).
+    user_agent: str = (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
+    )
 
     # Output directories
     output_dir: str = "cleaned_output"
@@ -205,6 +228,32 @@ class CrawlerConfig:
         # Browser configuration
         if "BROWSER_TYPE" in os.environ:
             config.browser_type = os.environ["BROWSER_TYPE"]
+
+        if "BROWSER_CHANNEL" in os.environ:
+            config.browser_channel = os.environ["BROWSER_CHANNEL"]
+
+        if "CHALLENGE_WAIT" in os.environ:
+            config.challenge_wait = int(os.environ["CHALLENGE_WAIT"])
+
+        if "MAGIC" in os.environ:
+            config.magic = os.environ["MAGIC"].lower() in ["true", "1", "yes"]
+
+        if "SIMULATE_USER" in os.environ:
+            config.simulate_user = os.environ["SIMULATE_USER"].lower() in [
+                "true",
+                "1",
+                "yes",
+            ]
+
+        if "OVERRIDE_NAVIGATOR" in os.environ:
+            config.override_navigator = os.environ["OVERRIDE_NAVIGATOR"].lower() in [
+                "true",
+                "1",
+                "yes",
+            ]
+
+        if "USER_AGENT" in os.environ:
+            config.user_agent = os.environ["USER_AGENT"]
 
         if "HEADLESS" in os.environ:
             config.headless = os.environ["HEADLESS"].lower() in ["true", "1", "yes"]

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -48,7 +48,13 @@ async def crawl(config: CrawlerConfig = None):
         exclude_social_media_links=True,
         exclude_external_images=True,
         verbose=config.verbose,
-        delay_before_return_html=config.delay_before_return_html,
+        # Longer wait on the root fetch so a JS anti-bot challenge can solve,
+        # set its clearance cookie, and reload to the real page before capture.
+        delay_before_return_html=config.challenge_wait,
+        magic=config.magic,
+        simulate_user=config.simulate_user,
+        override_navigator=config.override_navigator,
+        user_agent=config.user_agent,
         process_iframes=True,  # Process content within iframes
         remove_overlay_elements=True,  # Remove popups/overlays that block scrolling
         js_code=[
@@ -81,6 +87,10 @@ async def crawl(config: CrawlerConfig = None):
         exclude_external_images=True,
         verbose=config.verbose,
         delay_before_return_html=config.delay_before_return_html,
+        magic=config.magic,
+        simulate_user=config.simulate_user,
+        override_navigator=config.override_navigator,
+        user_agent=config.user_agent,
         process_iframes=True,  # Process content within iframes
         remove_overlay_elements=True,  # Remove popups/overlays that block scrolling
         js_code=[
@@ -101,6 +111,10 @@ async def crawl(config: CrawlerConfig = None):
         exclude_external_images=True,
         verbose=config.verbose,
         delay_before_return_html=config.delay_before_return_html,
+        magic=config.magic,
+        simulate_user=config.simulate_user,
+        override_navigator=config.override_navigator,
+        user_agent=config.user_agent,
         process_iframes=True,  # Process content within iframes
         remove_overlay_elements=True,  # Remove popups/overlays that block scrolling
         js_code=[
@@ -117,10 +131,13 @@ async def crawl(config: CrawlerConfig = None):
 
     browser_config = BrowserConfig(
         browser_type=config.browser_type,
+        chrome_channel=config.browser_channel,
+        channel=config.browser_channel,
         headless=config.headless,
         light_mode=config.light_mode,
         text_mode=config.text_mode,
         ignore_https_errors=config.ignore_https_errors,
+        user_agent=config.user_agent,
     )
 
     start_urls = config.start_urls
@@ -265,14 +282,23 @@ async def crawl(config: CrawlerConfig = None):
         url = getattr(res, "url", "NO_URL")
         print(f"  Result {i}: URL={url}, Status={status}")
 
-    # Accept all 2xx success codes (200, 201, 202, 204, 206, etc.)
-    valid_pages = [
-        res
-        for res in all_results
-        if hasattr(res, "status_code")
-        and res.status_code is not None
-        and 200 <= res.status_code <= 301
-    ]
+    # Accept all 2xx/301 success codes, OR pages that carry real content despite
+    # an anomalous status. Some anti-bot WAFs (e.g. SiteGround) serve the real
+    # page with a 403/202 after the JS challenge clears — keep those, but still
+    # reject genuine block/challenge pages.
+    valid_pages = []
+    for res in all_results:
+        status = getattr(res, "status_code", None)
+        if status is None:
+            continue
+        if 200 <= status <= 301:
+            valid_pages.append(res)
+        elif has_real_content(res):
+            print(
+                f"⚠️  Keeping {getattr(res, 'url', '?')} despite status {status}: "
+                f"real content detected (anti-bot WAF likely)"
+            )
+            valid_pages.append(res)
     print(f"Debug: After status filtering: {len(valid_pages)} valid pages")
 
     print("Post-processing results to remove links...")
@@ -335,6 +361,40 @@ async def crawl(config: CrawlerConfig = None):
     print(f"✅ Crawling complete! Processed {len(final_results)} unique pages")
 
     return final_results  # Return the processed results
+
+
+BLOCK_PAGE_MARKERS = [
+    "sgchallenge",
+    "robot challenge",
+    ".well-known/captcha",
+    "checking your browser",
+    "just a moment",
+    "attention required",
+    "access denied",
+    "you have been blocked",
+    "ddos protection",
+]
+
+# Minimum HTML size for a non-2xx page to be treated as real content rather
+# than a block page. The SiteGround challenge screen is ~12KB; real pages are
+# much larger.
+MIN_REAL_CONTENT_BYTES = 20000
+
+
+def is_block_page(html):
+    """Return True if the HTML looks like an anti-bot challenge or block page."""
+    low = (html or "").lower()
+    return any(marker in low for marker in BLOCK_PAGE_MARKERS)
+
+
+def has_real_content(result):
+    """Return True if a result carries substantial real content (not a block page).
+
+    Used to keep pages that an anti-bot WAF serves with an anomalous status code
+    (e.g. 403/202) after a JS challenge has cleared.
+    """
+    html = getattr(result, "html", "") or ""
+    return len(html) >= MIN_REAL_CONTENT_BYTES and not is_block_page(html)
 
 
 def check_captcha_indicators(result, url):

--- a/render.yaml
+++ b/render.yaml
@@ -21,6 +21,21 @@ services:
     envVars:
       - key: PLAYWRIGHT_BROWSERS_PATH
         value: "/opt/render/project/playwright"
+      # --- Anti-bot / browser config (server-friendly overrides) ---
+      # Render is headless Linux with no real Chrome, so use bundled Chromium
+      # headless. Tested: headless Chromium + fixed UA + magic clears the
+      # SiteGround JS challenge on its own.
+      - key: HEADLESS
+        value: "true"
+      - key: BROWSER_CHANNEL
+        value: "chromium"
+      # Single fixed UA (Linux Chrome, matching the bundled Chromium 131). Must
+      # stay constant or anti-bot clearance cookies break across requests.
+      - key: USER_AGENT
+        value: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+      # Seconds to wait on the root fetch for the JS challenge to resolve.
+      - key: CHALLENGE_WAIT
+        value: "12"
       # Secret environment variables - set in Render dashboard
       - key: OPENAI_API_KEY
         sync: false
@@ -35,3 +50,37 @@ services:
       - key: EXPECTED_CHUNKS
         value: 1
     autoDeploy: false
+
+  # --- Docker alternative -------------------------------------------------
+  # If the native Python env above fails to launch Chromium (missing system
+  # libraries), comment out the service above and uncomment this one. It uses
+  # the Dockerfile (official Playwright image with Chromium + all OS deps).
+  # Note: do NOT set PLAYWRIGHT_BROWSERS_PATH here — the image manages it.
+  #
+  # - type: cron
+  #   name: web-crawler
+  #   runtime: image
+  #   dockerfilePath: ./Dockerfile
+  #   schedule: "0 9 * * *"
+  #   envVars:
+  #     - key: HEADLESS
+  #       value: "true"
+  #     - key: BROWSER_CHANNEL
+  #       value: "chromium"
+  #     - key: USER_AGENT
+  #       value: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+  #     - key: CHALLENGE_WAIT
+  #       value: "12"
+  #     - key: OPENAI_API_KEY
+  #       sync: false
+  #     - key: START_URLS
+  #       sync: false
+  #     - key: PINECONE_API_KEY
+  #       sync: false
+  #     - key: PINECONE_INDEX_NAME
+  #       sync: false
+  #     - key: SENDGRID_API_KEY
+  #       sync: false
+  #     - key: EXPECTED_CHUNKS
+  #       value: 1
+  #   autoDeploy: false


### PR DESCRIPTION
## Problem
Crawls of SiteGround-hosted sites (e.g. `gefonline-sales.eu`) returned **0 links / 0 valid pages**. SiteGround serves a JS "Robot Challenge Screen" (`sgchallenge`, `/.well-known/captcha/`, HTTP 202) instead of the page. It is a JS proof-of-work, not an interactive CAPTCHA — a properly configured browser passes it automatically.

## Root causes
1. **Too detectable + captured too early.** `headless` + `text_mode` + `light_mode` with no stealth, and a 3s wait that returned the challenge screen before its JS resolved and reloaded.
2. **Random UA per request.** With `magic=True`, crawl4ai regenerates a new User-Agent on every `arun()`. SiteGround binds clearance to the UA, so the cookie broke between fetches → intermittent 403s (link-collection pass got 403/0-links while a later pass got 200).

## Changes
- **Stealth/browser config** (`crawler/config.py`, `crawler/crawl.py`): headful real Chrome locally / headless Chromium on servers; `magic` + `simulate_user` + `override_navigator` on every run config; longer `challenge_wait` (12s) on the root/link-collection fetch.
- **Pinned User-Agent** across the whole session (`USER_AGENT` env) — the key fix for determinism.
- **Content-aware status filter**: keep real pages a WAF serves with a 403/202 (`has_real_content`), still reject genuine block/challenge pages.
- **`render.yaml`**: server-friendly env vars (`HEADLESS`, `BROWSER_CHANNEL`, `USER_AGENT`, `CHALLENGE_WAIT`) + a commented Docker-environment alternative.
- **`Dockerfile`**: official Playwright image (Chromium + OS deps) as a fallback if Render's native env lacks Chromium's system libraries.

## Verification (against gefonline-sales.eu)
- Link discovery now deterministic: `16 pages, 728 links, 0 blocked` — identical across 3 repeated runs.
- Multi-page session all `200` (home/about/contact); clearance cookie stays valid.
- **Headless** bundled Chromium clears the challenge on its own (`status=200, cleared=True`) — no display/real-Chrome needed on the server.

## Not addressed here (operational)
- The test account's **OpenAI key is out of quota**, which blocks the LLM content filter + summarization. Top up billing before a production run.
- Optional reliability booster: whitelist Render's static outbound IP in each site's SiteGround so the challenge never appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
