### PR TITLE
Add Upstash Vector dual-write alongside Pinecone

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,13 @@ OPENAI_API_KEY=your_openai_api_key_here
 PINECONE_API_KEY=your_pinecone_api_key_here
 PINECONE_INDEX_NAME=your_index_name_here
 
+# Upstash Vector Configuration (dual-write target during the Pinecone migration)
+# One shared index; set creds to enable dual-write. Leave unset to skip Upstash.
+UPSTASH_VECTOR_REST_URL=your_upstash_vector_rest_url_here
+UPSTASH_VECTOR_REST_TOKEN=your_upstash_vector_rest_token_here
+# Per-company namespace. Defaults to PINECONE_INDEX_NAME when unset.
+# UPSTASH_NAMESPACE=your_index_name_here
+
 # Crawler Configuration
 # Comma-separated list of start URLs
 START_URLS=https://example.com/page1,https://example.com/page2

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -76,6 +76,9 @@ class CrawlerConfig:
     record_retention_hours: int = 1
     upsert_batch_size: int = 50
     delete_old_records: bool = True
+    # Upstash namespace (dual-write target during the Pinecone migration).
+    # Defaults to the Pinecone index name when unset, so each company maps 1:1.
+    upstash_namespace: str = None
 
     # Processing control
     dry_run: bool = False
@@ -157,6 +160,9 @@ class CrawlerConfig:
                 "1",
                 "yes",
             ]
+
+        if "UPSTASH_NAMESPACE" in os.environ:
+            config.upstash_namespace = os.environ["UPSTASH_NAMESPACE"]
 
         if "DRY_RUN" in os.environ:
             config.dry_run = os.environ["DRY_RUN"].lower() in ["true", "1", "yes"]

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -11,7 +11,7 @@ from sendgrid.helpers.mail import Mail, Email, Content
 from crawler.crawl import crawl
 from chunk_content import chunk_content
 from summary import summarize_content
-from vectordb.pinecone import upload_chunks
+from vectordb.upload import upload_chunks
 from crawler.config import CrawlerConfig
 
 # Create logs directory if it doesn't exist

--- a/render.yaml
+++ b/render.yaml
@@ -30,6 +30,15 @@ services:
         sync: false
       - key: PINECONE_INDEX_NAME
         sync: false
+      # Upstash Vector dual-write target (one shared index, namespace per
+      # company). Set in the dashboard. UPSTASH_NAMESPACE defaults to
+      # PINECONE_INDEX_NAME when unset.
+      - key: UPSTASH_VECTOR_REST_URL
+        sync: false
+      - key: UPSTASH_VECTOR_REST_TOKEN
+        sync: false
+      - key: UPSTASH_NAMESPACE
+        sync: false
       - key: SENDGRID_API_KEY
         sync: false
       - key: EXPECTED_CHUNKS

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 crawl4ai~=0.6.0
 python-dotenv~=1.0.0
 pinecone~=6.0.0
+upstash-vector~=0.8.0
 langchain~=0.3.0
 langchain-experimental~=0.3.0
 langchain-openai~=0.3.0

--- a/vectordb/base.py
+++ b/vectordb/base.py
@@ -1,0 +1,20 @@
+"""
+Shared interface for vector-database uploaders.
+
+Both the Pinecone and Upstash uploaders implement this interface so the
+dual-write coordinator in ``vectordb/upload.py`` can treat them uniformly.
+"""
+
+from abc import ABC, abstractmethod
+
+
+class VectorDBUploader(ABC):
+    """Connects to a vector store, upserts crawled chunks, and prunes stale ones."""
+
+    @abstractmethod
+    def upsert_records(self, records) -> int:
+        """Upsert the given records. Returns the number of records upserted."""
+
+    @abstractmethod
+    def delete_older_than_retention_period(self) -> int:
+        """Delete records older than the retention window. Returns the count deleted."""

--- a/vectordb/pinecone.py
+++ b/vectordb/pinecone.py
@@ -17,17 +17,16 @@ Usage:
     python upload_to_pinecone_new.py [--dry-run] [--input-dir DIRECTORY]
 """
 
-import os
-import sys
 import logging
 import time
 from datetime import datetime, timedelta
 import re
-from dotenv import load_dotenv
 
 # Import from the pinecone.control module where the Pinecone class is defined
 from pinecone import Pinecone
 import unicodedata
+
+from vectordb.base import VectorDBUploader
 
 # Configure logging
 logging.basicConfig(
@@ -36,7 +35,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-class PineconeUploader:
+class PineconeUploader(VectorDBUploader):
     """
     Handles connecting to Pinecone, uploading new records using integrated
     inference, and deleting outdated web-scraped records by wiping the
@@ -282,56 +281,3 @@ class PineconeUploader:
         except Exception as e:
             logger.error(f"Error during deletion of old records: {e}")
             raise
-
-
-def upload_chunks(chunks, config=None):
-    """
-    Upload chunks to Pinecone vector database.
-
-    Args:
-        chunks: List of chunks to upload
-        config: Optional configuration object
-    """
-    load_dotenv(override=True)
-    # Validate required environment variables.
-    required_vars = ["PINECONE_API_KEY", "PINECONE_INDEX_NAME"]
-    missing = [var for var in required_vars if not os.getenv(var)]
-    if missing:
-        logger.error(f"Missing environment variables: {', '.join(missing)}")
-        sys.exit(1)
-
-    api_key = os.getenv("PINECONE_API_KEY")
-    index_name = os.getenv("PINECONE_INDEX_NAME")
-
-    # Get configuration from config object if provided
-    chunk_id_prefix = None
-    record_retention_hours = None
-    upsert_batch_size = None
-    delete_old_records = None
-
-    if config:
-        chunk_id_prefix = getattr(config, "chunk_id_prefix", None)
-        record_retention_hours = getattr(config, "record_retention_hours", None)
-        upsert_batch_size = getattr(config, "upsert_batch_size", None)
-        delete_old_records = getattr(config, "delete_old_records", None)
-
-    # Initialize the PineconeUploader instance with configuration
-    uploader = PineconeUploader(
-        api_key,
-        index_name,
-        chunk_id_prefix=chunk_id_prefix,
-        record_retention_hours=record_retention_hours,
-        upsert_batch_size=upsert_batch_size,
-        delete_old_records=delete_old_records,
-    )
-
-    deleted_count = uploader.delete_older_than_retention_period()
-    logger.info(f"Deleted {deleted_count} old records")
-
-    upserted_count = uploader.upsert_records(chunks)
-    logger.info(f"Upserted {upserted_count} records")
-
-    logger.info(
-        f"Operation complete: {upserted_count} records upserted, "
-        f"{deleted_count} old records deleted."
-    )

--- a/vectordb/upload.py
+++ b/vectordb/upload.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+Vector-store upload coordinator.
+
+During the Pinecone -> Upstash migration this dual-writes every crawl to both
+stores. Pinecone remains the source of truth (its failures propagate and abort
+the run); Upstash writes are best-effort (failures are logged but never fail the
+crawl). Upstash is only attempted when its credentials are present.
+
+Once the migration is complete, drop the Pinecone branch and keep Upstash only.
+"""
+
+import logging
+import os
+import sys
+from dotenv import load_dotenv
+
+from vectordb.pinecone import PineconeUploader
+from vectordb.upstash import UpstashUploader
+
+logger = logging.getLogger(__name__)
+
+
+def _vector_db_kwargs(config):
+    """Extract the shared uploader settings from the crawler config."""
+    return dict(
+        chunk_id_prefix=getattr(config, "chunk_id_prefix", None) if config else None,
+        record_retention_hours=(
+            getattr(config, "record_retention_hours", None) if config else None
+        ),
+        upsert_batch_size=getattr(config, "upsert_batch_size", None) if config else None,
+        delete_old_records=(
+            getattr(config, "delete_old_records", None) if config else None
+        ),
+    )
+
+
+def _run(uploader, chunks, label):
+    """Delete stale records then upsert the fresh batch, mirroring prior behavior."""
+    deleted_count = uploader.delete_older_than_retention_period()
+    logger.info(f"[{label}] Deleted {deleted_count} old records")
+
+    upserted_count = uploader.upsert_records(chunks)
+    logger.info(f"[{label}] Upserted {upserted_count} records")
+
+    logger.info(
+        f"[{label}] Operation complete: {upserted_count} records upserted, "
+        f"{deleted_count} old records deleted."
+    )
+
+
+def upload_chunks(chunks, config=None):
+    """
+    Upload chunks to the configured vector store(s).
+
+    Args:
+        chunks: List of chunks to upload
+        config: Optional configuration object
+    """
+    load_dotenv(override=True)
+
+    kwargs = _vector_db_kwargs(config)
+
+    # --- Pinecone: source of truth, failures abort the run ---
+    required_vars = ["PINECONE_API_KEY", "PINECONE_INDEX_NAME"]
+    missing = [var for var in required_vars if not os.getenv(var)]
+    if missing:
+        logger.error(f"Missing environment variables: {', '.join(missing)}")
+        sys.exit(1)
+
+    index_name = os.getenv("PINECONE_INDEX_NAME")
+    pinecone_uploader = PineconeUploader(
+        os.getenv("PINECONE_API_KEY"),
+        index_name,
+        **kwargs,
+    )
+    _run(pinecone_uploader, chunks, "pinecone")
+
+    # --- Upstash: best-effort dual-write, never fails the crawl ---
+    upstash_url = os.getenv("UPSTASH_VECTOR_REST_URL")
+    upstash_token = os.getenv("UPSTASH_VECTOR_REST_TOKEN")
+    if not (upstash_url and upstash_token):
+        logger.info(
+            "Upstash not configured (UPSTASH_VECTOR_REST_URL / "
+            "UPSTASH_VECTOR_REST_TOKEN unset); skipping dual-write."
+        )
+        return
+
+    # One shared Upstash index, one namespace per company. Default the namespace
+    # to the Pinecone index name so each company maps 1:1 without extra config.
+    namespace = (
+        getattr(config, "upstash_namespace", None) if config else None
+    ) or os.getenv("UPSTASH_NAMESPACE") or index_name
+
+    try:
+        upstash_uploader = UpstashUploader(
+            upstash_url,
+            upstash_token,
+            namespace,
+            **kwargs,
+        )
+        _run(upstash_uploader, chunks, "upstash")
+    except Exception as e:
+        logger.error(
+            f"[upstash] dual-write failed (continuing; Pinecone is source "
+            f"of truth): {e}"
+        )

--- a/vectordb/upstash.py
+++ b/vectordb/upstash.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Upstash Vector uploader.
+
+Mirrors ``PineconeUploader`` (vectordb/pinecone.py) but targets Upstash Vector.
+Like Pinecone's integrated inference, Upstash embeds raw text server-side when
+the index is created with a hosted embedding model, so we upsert the chunk text
+via the ``data`` field rather than precomputing vectors.
+
+Per-company data is isolated by namespace: one shared Upstash index, one
+namespace per company (the namespace mirrors the company's Pinecone index name).
+"""
+
+import logging
+import re
+import time
+import unicodedata
+from datetime import datetime, timedelta
+
+from upstash_vector import Index
+from upstash_vector.types import Data
+
+logger = logging.getLogger(__name__)
+
+
+class UpstashUploader:
+    """
+    Handles connecting to Upstash Vector, uploading new records using the
+    built-in embedding model, and deleting outdated web-scraped records by
+    timestamp within the company's namespace.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        token: str,
+        namespace: str,
+        chunk_id_prefix,
+        record_retention_hours,
+        upsert_batch_size,
+        delete_old_records,
+    ):
+        """
+        Args:
+            url: Upstash Vector REST URL
+            token: Upstash Vector REST token
+            namespace: Per-company namespace (mirrors the Pinecone index name)
+            chunk_id_prefix: Prefix for chunk IDs
+            record_retention_hours: How many hours to keep old records before deletion
+            upsert_batch_size: Number of records to upsert in each batch
+            delete_old_records: Whether to delete old records
+        """
+        self.namespace = namespace or ""
+        self.chunk_id_prefix = chunk_id_prefix
+        self.record_retention_hours = record_retention_hours
+        self.upsert_batch_size = upsert_batch_size
+        self.delete_old_records = delete_old_records
+
+        self.index = Index(url=url, token=token)
+
+        logger.info(f"Initializing Upstash Vector client, namespace: '{self.namespace}'")
+        logger.info(f"Using chunk ID prefix: {self.chunk_id_prefix}")
+        logger.info(f"Record retention hours: {self.record_retention_hours}")
+        logger.info(f"Upsert batch size: {self.upsert_batch_size}")
+        logger.info(f"Delete old records: {self.delete_old_records}")
+
+    def sanitize_vector_id(self, id_str: str) -> str:
+        """
+        Sanitize vector ID to ensure it contains only ASCII characters.
+        """
+        normalized = unicodedata.normalize("NFKD", id_str)
+        ascii_str = normalized.encode("ASCII", "ignore").decode("ASCII")
+        sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", ascii_str)
+        return sanitized
+
+    def upsert_records(self, records) -> int:
+        """
+        Upsert the provided records into the namespace using Upstash's built-in
+        embedding (raw text passed via the ``data`` field). Processed in batches.
+        """
+        try:
+            total_records = len(records)
+            logger.info(
+                f"Upserting {total_records} records into namespace: '{self.namespace}'"
+            )
+
+            # Format all records as Data objects (data -> embedded text, returned
+            # on query via include_data=True).
+            formatted_records = []
+            for record in records:
+                formatted_records.append(
+                    Data(
+                        id=self.sanitize_vector_id(
+                            f"{self.chunk_id_prefix}_{record.chunk_name}"
+                        ),
+                        data=record.markdown,
+                        metadata={
+                            "url": record.url,
+                            "upload_timestamp": datetime.now().isoformat(),
+                        },
+                    )
+                )
+
+            batch_size = self.upsert_batch_size
+            total_batches = (len(formatted_records) + batch_size - 1) // batch_size
+            records_upserted = 0
+
+            logger.info(
+                f"Processing {total_batches} batches of up to {batch_size} records each"
+            )
+
+            for i in range(total_batches):
+                start_idx = i * batch_size
+                end_idx = min(start_idx + batch_size, len(formatted_records))
+                batch = formatted_records[start_idx:end_idx]
+
+                self.index.upsert(vectors=batch, namespace=self.namespace)
+                records_upserted += len(batch)
+
+                logger.info(
+                    f"Completed batch {i+1}/{total_batches}. "
+                    f"Progress: {records_upserted}/{total_records}"
+                )
+
+                # Small pause between batches to avoid rate limiting
+                if i < total_batches - 1:
+                    time.sleep(0.5)
+
+            logger.info(
+                f"Upsert operation completed. "
+                f"Total records upserted: {records_upserted}"
+            )
+            return records_upserted
+        except Exception as e:
+            logger.error(f"Error during Upstash upsert: {e}")
+            raise
+
+    def delete_older_than_retention_period(self) -> int:
+        """
+        Delete records under this namespace whose id starts with the chunk
+        prefix and whose ``upload_timestamp`` metadata is older than the
+        retention period. Returns the number of deleted records.
+        """
+        if not self.delete_old_records:
+            logger.info("Record deletion is disabled, skipping.")
+            return 0
+
+        try:
+            retention_threshold = datetime.now() - timedelta(
+                hours=self.record_retention_hours
+            )
+            logger.info(
+                f"Deleting Upstash records older than "
+                f"{self.record_retention_hours} hours "
+                f"(threshold {retention_threshold.isoformat()})"
+            )
+
+            # Scan the namespace by prefix, collecting stale ids across all pages
+            # first, then delete — avoids mutating the set mid-pagination.
+            old_vector_ids = []
+            cursor = ""
+            while True:
+                res = self.index.range(
+                    cursor=cursor,
+                    prefix=self.chunk_id_prefix,
+                    limit=100,
+                    include_metadata=True,
+                    namespace=self.namespace,
+                )
+
+                for v in res.vectors:
+                    upload_timestamp = (v.metadata or {}).get("upload_timestamp")
+                    if not upload_timestamp:
+                        logger.warning(f"Vector {v.id} has no upload_timestamp metadata")
+                        continue
+                    try:
+                        if datetime.fromisoformat(upload_timestamp) < retention_threshold:
+                            old_vector_ids.append(v.id)
+                    except (ValueError, TypeError) as e:
+                        logger.warning(
+                            f"Could not parse timestamp {upload_timestamp} "
+                            f"for vector {v.id}: {e}"
+                        )
+
+                cursor = res.next_cursor
+                if not cursor:
+                    break
+
+            # Delete the stale ids in batches
+            total_deleted = 0
+            batch_size = self.upsert_batch_size
+            for i in range(0, len(old_vector_ids), batch_size):
+                batch = old_vector_ids[i : i + batch_size]
+                self.index.delete(ids=batch, namespace=self.namespace)
+                total_deleted += len(batch)
+
+            logger.info(
+                f"Successfully deleted {total_deleted} Upstash vectors older than "
+                f"{self.record_retention_hours} hours"
+            )
+            return total_deleted
+
+        except Exception as e:
+            logger.error(f"Error during deletion of old Upstash records: {e}")
+            raise


### PR DESCRIPTION
## Summary
- Adds `UpstashUploader` that mirrors `PineconeUploader` using Upstash's hosted `BAAI/bge-large-en-v1.5` embeddings (raw text, no external embedding API calls)
- Every crawl now dual-writes to both Pinecone (source of truth) and Upstash — Upstash failures are logged but never abort a crawl
- Introduces a `VectorDBUploader` ABC and a `vectordb/upload.py` coordinator; the old `upload_chunks` function is moved there

**Layout:** one shared Upstash index, one namespace per company = `PINECONE_INDEX_NAME` value. Maps 1:1 with `chat_configs.pinecone_index_name` in dialogue-foundry — no Supabase migration needed.

**Zero-risk rollout:** Upstash is only attempted when `UPSTASH_VECTOR_REST_URL` is set. Existing deployments without that env var are completely unaffected.

## New files
- `vectordb/base.py` — `VectorDBUploader` ABC
- `vectordb/upstash.py` — `UpstashUploader` (upsert via `Data.data`, retention via `range` + `delete` with prefix)
- `vectordb/upload.py` — dual-write coordinator (replaces `upload_chunks` in `pinecone.py`)

## Changed files
- `vectordb/pinecone.py` — `PineconeUploader` now subclasses the ABC; `upload_chunks` removed (moved to `upload.py`)
- `orchestrator.py` — import updated to `vectordb.upload`
- `crawler/config.py` — added `upstash_namespace` field (defaults to `PINECONE_INDEX_NAME`)
- `requirements.txt` — added `upstash-vector~=0.8.0`
- `.env.example`, `render.yaml` — added Upstash env var documentation

## Test plan
- [ ] Set `UPSTASH_VECTOR_REST_URL` + `UPSTASH_VECTOR_REST_TOKEN` and run `python orchestrator.py` for one company
- [ ] Confirm vectors appear in Upstash console under the expected namespace
- [ ] Confirm Pinecone index is unchanged
- [ ] Run without Upstash creds set — confirm crawl completes normally (Upstash skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)