### PR TITLE
Fix browser launch: clear crawl4ai chrome_channel to use managed Chromium

### DIFF
--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -139,6 +139,10 @@ async def crawl(config: CrawlerConfig = None):
         ignore_https_errors=config.ignore_https_errors,
         user_agent=config.user_agent,
     )
+    # crawl4ai 0.6.x defaults chrome_channel="chromium" which Playwright
+    # treats as a channel lookup and falls back to system Chrome. Clear it
+    # so Playwright uses the managed playwright-chromium instead.
+    browser_config.chrome_channel = ""
 
     start_urls = config.start_urls
 

--- a/render.yaml
+++ b/render.yaml
@@ -5,17 +5,7 @@ services:
     name: web-crawler
     plan: standard
     env: python
-    buildCommand: |
-      # Install dependencies
-      pip install -r requirements.txt
-      pip install -e .
-      
-      # Install Playwright with only Chromium
-      pip install playwright
-      
-      # Set Playwright browsers path to Render-specific directory
-      export PLAYWRIGHT_BROWSERS_PATH=/opt/render/project/playwright
-      python -m playwright install chromium
+    buildCommand: python3 -m pip install -r requirements.txt && python3 -m pip install -e . && PLAYWRIGHT_BROWSERS_PATH=/opt/render/project/playwright python3 -m playwright install chromium
     startCommand: python orchestrator.py
     schedule: "0 9 * * *"  # Run at 9 AM UTC every 2 days
     envVars:


### PR DESCRIPTION
## Summary

- crawl4ai 0.6.x always sets `chrome_channel="chromium"` in `BrowserConfig` and passes it as `channel=` to `playwright.chromium.launch()`. Playwright treats `"chromium"` as a **channel lookup** (not the managed browser), falls back to system Chrome at `/opt/google/chrome/chrome` — which isn't installed on Render.
- Fix: set `browser_config.chrome_channel = ""` after `BrowserConfig` construction so the `channel=` arg is never passed and Playwright uses the installed managed Chromium directly.
- Also fixes `render.yaml` `buildCommand`: collapses the broken multiline `|` block (each line ran as a separate subprocess, so `export` and `pip` failed) into a single `&&` chain. Inline `PLAYWRIGHT_BROWSERS_PATH=... playwright install chromium` ensures the browser lands in the same path the runtime env var points to.

## Test plan

- [ ] Deploy to Render and confirm build succeeds (no `pip: command not found` or `export` errors)
- [ ] Confirm crawler runs: no `BrowserType.launch: Chromium distribution 'chrome' is not found` error at runtime
- [ ] Crawl completes and vectors are upserted to Pinecone

🤖 Generated with [Claude Code](https://claude.com/claude-code)