### PR TITLE
fix: stop .env clobbering caller env, and keep scrape stdout pure JSON

### DIFF
--- a/crawler/config.py
+++ b/crawler/config.py
@@ -9,7 +9,11 @@ from dataclasses import dataclass, field
 from typing import List
 from dotenv import load_dotenv
 
-load_dotenv(override=True)
+# override=False: fill in anything not already set in the environment, but
+# never clobber vars a caller (e.g. demo-setup's per-company subprocess env)
+# explicitly set. override=True previously let a stale .env value silently
+# replace the real per-invocation START_URLS/MAX_DEPTH/HEADLESS.
+load_dotenv(override=False)
 
 
 @dataclass

--- a/scrape_page.py
+++ b/scrape_page.py
@@ -68,6 +68,9 @@ def _build_browser_config(config: CrawlerConfig) -> BrowserConfig:
         text_mode=config.text_mode,
         ignore_https_errors=config.ignore_https_errors,
         user_agent=config.user_agent,
+        # crawl4ai prints its own init banner straight to stdout when verbose,
+        # which would corrupt the pure-JSON contract this script promises.
+        verbose=False,
     )
     # Same fix as crawl.py: clear chrome_channel so Playwright uses managed
     # chromium instead of falling back to a system Chrome lookup.


### PR DESCRIPTION
Two bugs found while driving this crawler as a subprocess from `dialogue-foundry`'s demo-setup service.

## `load_dotenv(override=True)` clobbered the caller's environment

demo-setup spawns `orchestrator.py` with a per-company `START_URLS`, `MAX_DEPTH` and `HEADLESS`. With `override=True`, the checked-out `.env` won — so a stale `.env` left over from an unrelated deep-crawl job silently:

- redirected the crawl to **a different company's website** (`gefonline-sales.eu`),
- ran at depth 3 instead of 0 (~99 pages / 15 min instead of ~11 pages / 80s),
- and opened a **visible** browser window despite `HEADLESS=true`.

`override=False` fills in anything not already set, without overwriting what the caller explicitly chose. This is the behavior every caller already assumed.

## `scrape_page.py` corrupted its own stdout

The script promises pure JSON on stdout (the Node side does `JSON.parse(stdout)`), but crawl4ai prints an `[INIT]....` banner straight to stdout when verbose, so parsing failed. `BrowserConfig` now sets `verbose=False`. Logs still go to stderr, which the caller reads separately.

## Testing

Both were reproduced before the fix and confirmed after, by running the demo-setup pipeline end-to-end against `untap-ai.com`: the crawl now targets the correct site, at depth 0, headless, and returns parseable JSON.

Depends on nothing; `dialogue-foundry` needs this merged for its demo queue to work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)