### PR TITLE
feat: in-browser brand probe for demo colors and logo detection

### DIFF
--- a/brand_probe.js
+++ b/brand_probe.js
@@ -1,0 +1,607 @@
+/* Brand-signal probe, evaluated inside the settled page by scrape_page.py.
+ *
+ * The old approach regexed `background-color` out of inline style="" attrs and
+ * <style> blocks in the returned HTML. Modern sites keep ~all their color in
+ * external stylesheets, so that saw almost nothing and the demo fell back to a
+ * generic blue. Here we're already inside a real browser with the cascade
+ * resolved, so we can just ask getComputedStyle.
+ *
+ * Returns a JSON-serializable object; the caller reads it off
+ * result.js_execution_result. Everything is best-effort — a throw anywhere
+ * would lose the whole scrape, so each section is independently guarded. */
+(() => {
+  /* crawl4ai's `simulate_user` scrolls the page to look human, so by the time we
+   * run, getBoundingClientRect().top is relative to wherever it stopped. Scroll
+   * back to the origin (lazy images have already loaded) so viewport coords and
+   * document coords coincide and "is this in the header?" is a simple top < 200.
+   * Fixed/sticky headers make the scrollY-offset alternative wrong anyway. */
+  try {
+    window.scrollTo(0, 0)
+  } catch {
+    /* not fatal */
+  }
+
+  /* Our own chat widget, if this prospect is already a customer. Its logo has
+   * alt="Brand Logo" and its buttons are painted in whatever primaryColor we
+   * configured last time — sampling it would make the probe read back our own
+   * output instead of the site's real brand. Exclude the whole subtree. */
+  const WIDGET_SELECTOR =
+    '#dialogue-foundry-app, [id*="dialogue-foundry"], [class*="dialogue-foundry"], [data-dialogue-foundry-id]'
+  const isOurWidget = el => Boolean(el.closest(WIDGET_SELECTOR))
+
+  const resolveUrl = (href, base) => {
+    try {
+      return new URL(href, base).href
+    } catch {
+      return href
+    }
+  }
+
+  const clamp01 = n => Math.min(1, Math.max(0, n))
+
+  /* Parse the handful of color notations getComputedStyle actually emits
+   * (rgb/rgba) plus author-written hex from CSS custom properties, which are
+   * *not* resolved to rgb() the way real properties are. */
+  const parseColor = value => {
+    if (typeof value !== 'string') return null
+    const raw = value.trim()
+    if (!raw || raw === 'transparent' || raw === 'currentcolor') return null
+
+    const rgb = raw.match(
+      /^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:\s*[,/]\s*([\d.%]+))?\s*\)$/i
+    )
+    if (rgb) {
+      let alpha = 1
+      if (rgb[4] !== undefined) {
+        alpha = rgb[4].endsWith('%')
+          ? parseFloat(rgb[4]) / 100
+          : parseFloat(rgb[4])
+      }
+      return { r: +rgb[1], g: +rgb[2], b: +rgb[3], a: clamp01(alpha) }
+    }
+
+    const hex = raw.match(/^#([0-9a-f]{3,8})$/i)
+    if (hex) {
+      let h = hex[1]
+      if (h.length === 3 || h.length === 4) h = [...h].map(c => c + c).join('')
+      if (h.length !== 6 && h.length !== 8) return null
+      return {
+        r: parseInt(h.slice(0, 2), 16),
+        g: parseInt(h.slice(2, 4), 16),
+        b: parseInt(h.slice(4, 6), 16),
+        a: h.length === 8 ? parseInt(h.slice(6, 8), 16) / 255 : 1
+      }
+    }
+    return null
+  }
+
+  const toHex = ({ r, g, b }) =>
+    '#' +
+    [r, g, b]
+      .map(n => Math.round(n).toString(16).padStart(2, '0'))
+      .join('')
+      .toLowerCase()
+
+  const saturationOf = ({ r, g, b }) => {
+    const max = Math.max(r, g, b) / 255
+    const min = Math.min(r, g, b) / 255
+    const l = (max + min) / 2
+    if (max === min) return { s: 0, l }
+    const d = max - min
+    return { s: l > 0.5 ? d / (2 - max - min) : d / (max + min), l }
+  }
+
+  /* The browser's built-in unvisited/visited link colors. They show up on any
+   * page with an unstyled <a>, are saturated enough to pass the filter, and are
+   * never anybody's brand color. */
+  const UA_DEFAULT_COLORS = new Set(['#0000ee', '#0000ff', '#551a8b'])
+
+  /* Drop whites, blacks, greys and near-transparent overlays. These dominate
+   * any usage count on a real page and are never the brand color. */
+  const isBrandworthy = color => {
+    if (!color || color.a < 0.6) return false
+    if (UA_DEFAULT_COLORS.has(toHex(color))) return false
+    const { s, l } = saturationOf(color)
+    return s >= 0.15 && l >= 0.08 && l <= 0.92
+  }
+
+  /* Relaxed fallback for genuinely monochrome brands (black type on cream, no
+   * saturated accent anywhere): drop the saturation requirement, but still hard
+   * -exclude anything white-ish or black-ish. White/near-white is essentially
+   * always a page or card background, never a chosen brand color — even for a
+   * monochrome brand the "color" worth surfacing is their near-black text/logo
+   * ink, not the paper it sits on. */
+  const isDistinct = color => {
+    if (!color || color.a < 0.6) return false
+    if (UA_DEFAULT_COLORS.has(toHex(color))) return false
+    const { l } = saturationOf(color)
+    return l >= 0.04 && l <= 0.85
+  }
+
+  const safe = fn => {
+    try {
+      return fn()
+    } catch {
+      return null
+    }
+  }
+
+  /* ---- CSS custom properties on :root ------------------------------------
+   * The single strongest signal on any site built this decade: --primary,
+   * --brand-color, --wp--preset--color--accent, --e-global-color-primary.
+   *
+   * Two ways in, because neither alone is enough:
+   *   1. Enumerate authored :root rules. Free names we'd never guess, but
+   *      `sheet.cssRules` throws on cross-origin stylesheets (most CDN-hosted
+   *      sites), so this silently returns nothing on plenty of pages.
+   *   2. Probe a fixed list of conventional names. getComputedStyle resolves a
+   *      custom property no matter which stylesheet declared it, cross-origin
+   *      included — so this is the one that actually fires on Stripe et al.
+   * Union the two. */
+  const WELL_KNOWN_VARS = [
+    '--primary',
+    '--primary-color',
+    '--color-primary',
+    '--brand',
+    '--brand-color',
+    '--color-brand',
+    '--brand-primary',
+    '--accent',
+    '--accent-color',
+    '--color-accent',
+    '--secondary',
+    '--secondary-color',
+    '--color-secondary',
+    '--theme-color',
+    '--main-color',
+    '--bs-primary', // Bootstrap 5
+    '--bs-link-color',
+    '--e-global-color-primary', // Elementor
+    '--e-global-color-secondary',
+    '--e-global-color-accent',
+    '--wp--preset--color--primary', // WordPress theme.json
+    '--wp--preset--color--secondary',
+    '--wp--preset--color--accent',
+    '--wp--preset--color--vivid-cyan-blue',
+    '--global-palette1', // Kadence
+    '--global-palette2',
+    '--astra-global-color-0', // Astra
+    '--ast-global-color-0',
+    '--color-accent-1', // Shopify Dawn
+    '--shopify-accent'
+  ]
+
+  const cssVariables = safe(() => {
+    const names = new Set(WELL_KNOWN_VARS)
+
+    for (const sheet of document.styleSheets) {
+      let rules
+      try {
+        rules = sheet.cssRules
+      } catch {
+        continue // cross-origin stylesheet, can't introspect — that's what the list is for
+      }
+      if (!rules) continue
+      for (const rule of rules) {
+        if (!rule.style || !rule.selectorText) continue
+        if (!/^(:root|html|body)\b/.test(rule.selectorText)) continue
+        for (const prop of rule.style) {
+          if (prop.startsWith('--')) names.add(prop)
+        }
+      }
+    }
+
+    const rootStyle = getComputedStyle(document.documentElement)
+    const out = []
+    const seen = new Set()
+    for (const name of names) {
+      const lower = name.toLowerCase()
+      // Carousel/lightbox libraries ship their own themed defaults on :root.
+      // --swiper-theme-color is #007aff on every Swiper site on earth.
+      if (/swiper|slick|glide|fancybox|splide|flickity|plyr|leaflet/.test(lower))
+        continue
+      const color = parseColor(rootStyle.getPropertyValue(name))
+      if (!color || !isBrandworthy(color)) continue
+      const hex = toHex(color)
+      if (seen.has(hex)) continue
+      seen.add(hex)
+      // Names that literally say "primary"/"brand"/"accent" outrank the rest.
+      let weight = 0
+      if (/primary|brand/.test(lower)) weight += 100
+      if (/accent/.test(lower)) weight += 60
+      if (/secondary/.test(lower)) weight += 40
+      if (/theme|main|palette1|color-0|color-1|colour/.test(lower)) weight += 20
+      out.push({ name, hex, weight })
+    }
+    return out.sort((a, b) => b.weight - a.weight).slice(0, 12)
+  })
+
+  /* ---- Computed styles on brand-bearing elements -------------------------
+   * Weight each color by (usage count) x (rendered area), so a nav bar and a
+   * CTA button outrank a single accented word deep in the footer. Area is
+   * square-rooted to keep one giant hero section from swamping everything. */
+  const collectComputed = brandworthyOnly => {
+    const SELECTOR = [
+      'button',
+      'a',
+      '[role="button"]',
+      'input[type="submit"]',
+      'input[type="button"]',
+      'header',
+      'nav',
+      'h1',
+      'h2',
+      '.btn',
+      '[class*="cta"]',
+      '[class*="button"]'
+    ].join(',')
+
+    const accept = brandworthyOnly ? isBrandworthy : isDistinct
+
+    const scores = new Map()
+    const bump = (color, area, source) => {
+      if (!accept(color)) return
+      const hex = toHex(color)
+      const entry = scores.get(hex) || { hex, score: 0, uses: 0, sources: {} }
+      entry.score += Math.sqrt(Math.max(area, 1))
+      entry.uses += 1
+      entry.sources[source] = (entry.sources[source] || 0) + 1
+      scores.set(hex, entry)
+    }
+
+    const elements = [...document.querySelectorAll(SELECTOR)].slice(0, 3000)
+    for (const el of elements) {
+      if (isOurWidget(el)) continue
+      const rect = el.getBoundingClientRect()
+      if (rect.width < 4 || rect.height < 4) continue
+      const style = getComputedStyle(el)
+      if (style.visibility === 'hidden' || style.display === 'none') continue
+
+      const area = rect.width * rect.height
+      const tag = el.tagName.toLowerCase()
+      // A filled CTA button is the strongest brand-color signal on any page;
+      // text color is weaker, and a border is weaker still.
+      bump(parseColor(style.backgroundColor), area, `${tag}:bg`)
+      bump(parseColor(style.color), area * 0.35, `${tag}:fg`)
+      // borderTopColor resolves to `currentColor` when no border is painted,
+      // which would just double-count every element's text color.
+      if (parseFloat(style.borderTopWidth) > 0) {
+        bump(parseColor(style.borderTopColor), area * 0.15, `${tag}:border`)
+      }
+    }
+
+    return [...scores.values()]
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 8)
+      .map(({ hex, score, uses, sources }) => ({
+        hex,
+        score: Math.round(score),
+        uses,
+        sources: Object.keys(sources).slice(0, 4)
+      }))
+  }
+
+  /* Brands like Allbirds are genuinely neutral — black type on cream, no
+   * saturated accent anywhere. The strict filter returns nothing for them, and
+   * an empty candidate list means the demo falls back to a generic blue that
+   * looks nothing like the site. Retry with the saturation floor removed so we
+   * still surface their near-black and their off-white. */
+  const computedColors = safe(() => {
+    const strict = collectComputed(true)
+    return strict.length ? strict : collectComputed(false)
+  })
+
+  /* ---- <meta name="theme-color"> ---------------------------------------- */
+  const themeColor = safe(() => {
+    const meta = document.querySelector('meta[name="theme-color"]')
+    const color = parseColor(meta?.getAttribute('content') || '')
+    return color && isBrandworthy(color) ? toHex(color) : null
+  })
+
+  /* ---- Resolved fonts ----------------------------------------------------
+   * The *computed* stack, not the authored declaration — tells us the webfont
+   * that actually loaded rather than whatever the first rule happened to say. */
+  const fonts = safe(() => {
+    const clean = stack =>
+      (stack || '').replace(/["']/g, '').trim() || null
+    const h1 = document.querySelector('h1')
+    return {
+      body: clean(getComputedStyle(document.body).fontFamily),
+      heading: h1 ? clean(getComputedStyle(h1).fontFamily) : null
+    }
+  })
+
+  /* ---- Logo --------------------------------------------------------------
+   * A logo is a small, wide-ish image pinned to the top-left of the header. It
+   * is NOT the 1200x600 hero background that happens to be the biggest <img> on
+   * the page — scoring by raw area (as the old heuristic did) picks the hero
+   * almost every time. Score by header membership and logo-ish geometry, and
+   * treat area as a *penalty* past a plausible logo size.
+   *
+   * `currentSrc` resolves srcset and lazy-loaded images, which reading `src`
+   * misses. Inline <svg> logos (Stripe, Vercel, most modern sites) have no URL
+   * at all, so serialize them to a data: URI — the widget renders that fine. */
+  const HEADER_PARTS = [
+    'header',
+    'nav',
+    '[class*="header"]',
+    '[id*="header"]',
+    '[class*="navbar"]',
+    '[role="banner"]'
+  ]
+  const HEADER_SELECTOR = HEADER_PARTS.join(', ')
+  // Soft penalty threshold for the TEXT-fallback ranking only (used when no
+  // screenshot is available to run vision against) — not a hard cutoff. A
+  // legitimate hero-style emblem (common for wineries/farms/boutique brands)
+  // can easily render at 350-450px; gating candidates out at this size is what
+  // caused the real West Hills Vineyards logo to never even reach the vision
+  // step. Actual full-bleed hero PHOTOS are rejected separately, by HERO_AREA.
+  const MAX_LOGO_AREA = 60000
+  // Nothing genuinely logo-shaped is bigger than this — past it, it's
+  // unambiguously a hero/background photo. Hard exclusion.
+  const HERO_AREA_CUTOFF = 500000 // ~700x700, or a 1000x500 hero banner
+  const MAX_SVG_BYTES = 24000
+
+  const encodeSvg = markup => {
+    const bytes = new TextEncoder().encode(markup)
+    let binary = ''
+    for (const byte of bytes) binary += String.fromCharCode(byte)
+    return 'data:image/svg+xml;base64,' + btoa(binary)
+  }
+
+  /* Serializing an inline <svg> straight out of the DOM produces markup whose
+   * paint comes from the page's cascade — `fill="var(--hds-color-text-solid)"`
+   * (Stripe) or a fill inherited from a stylesheet. Inside a data: URI neither
+   * resolves, and the logo renders invisible. Bake the *computed* fill/stroke
+   * onto every node before serializing. */
+  const svgToDataUri = svg => {
+    const clone = svg.cloneNode(true)
+    const originals = [svg, ...svg.querySelectorAll('*')]
+    const clones = [clone, ...clone.querySelectorAll('*')]
+    for (let i = 0; i < originals.length && i < clones.length; i++) {
+      const computed = getComputedStyle(originals[i])
+      const props =
+        originals[i].tagName.toLowerCase() === 'stop'
+          ? ['stop-color']
+          : ['fill', 'stroke']
+      for (const prop of props) {
+        const value = computed.getPropertyValue(prop)
+        if (value && value !== 'none' && !value.includes('var(')) {
+          clones[i].setAttribute(prop, value)
+        }
+      }
+      const width = computed.getPropertyValue('stroke-width')
+      if (width && width !== '1px') clones[i].setAttribute('stroke-width', width)
+    }
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+    return encodeSvg(clone.outerHTML)
+  }
+
+  /* Decorative or functional SVGs that look logo-shaped: sign-in cutout masks,
+   * animated text, icon sprites. A real mark is drawn from paths. */
+  const isLogoLikeSvg = svg =>
+    !svg.querySelector('mask, text, foreignObject') &&
+    Boolean(svg.querySelector('path, polygon, circle, rect'))
+
+  const svgNameScore = svg => {
+    const hay = [
+      svg.getAttribute('aria-label'),
+      svg.getAttribute('class'),
+      svg.getAttribute('id'),
+      svg.querySelector('title')?.textContent,
+      svg.querySelector('[id]')?.id
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLowerCase()
+    if (/logo|brand|wordmark/.test(hay)) return 80
+    if (/menu|hamburger|search|cart|close|arrow|chevron|social/.test(hay)) return -120
+    return 0
+  }
+
+  /* A logo is almost always wrapped in the anchor that points home. */
+  const linksHome = el => {
+    const anchor = el.closest('a[href]')
+    if (!anchor) return false
+    try {
+      const href = new URL(anchor.href, location.href)
+      return href.origin === location.origin && href.pathname.replace(/\/+$/, '') === ''
+    } catch {
+      return false
+    }
+  }
+
+  /* Authoritative when present: schema.org Organization.logo. Wix, Shopify and
+   * most CMSs emit it, and it survives hashed filenames that name-scoring can't
+   * read. */
+  const structuredLogos = () => {
+    const found = []
+    const visit = node => {
+      if (!node || typeof node !== 'object') return
+      if (Array.isArray(node)) return node.forEach(visit)
+      for (const key of ['logo', 'logoUrl', 'image']) {
+        const value = node[key]
+        const url = typeof value === 'string' ? value : value?.url
+        if (typeof url === 'string' && /^https?:/.test(url)) {
+          found.push({ url, weight: key === 'image' ? 30 : 120 })
+        }
+      }
+      Object.values(node).forEach(visit)
+    }
+    for (const script of document.querySelectorAll(
+      'script[type="application/ld+json"]'
+    )) {
+      try {
+        visit(JSON.parse(script.textContent))
+      } catch {
+        /* a malformed blob shouldn't sink the probe */
+      }
+    }
+    return found
+  }
+
+  const logos = safe(() => {
+    /* Score over everything that might name the image, not just the URL — Wix
+     * and friends serve `c08e45_c5e66d...~mv2.png` but set alt="Brand Logo". */
+    const nameScore = (...parts) => {
+      const lower = parts.filter(Boolean).join(' ').toLowerCase()
+      let n = 0
+      if (lower.includes('logo')) n += 60
+      if (lower.includes('brand')) n += 30
+      if (lower.includes('icon')) n += 10
+      if (/sprite|placeholder|hero|banner|background|bg-/.test(lower)) n -= 60
+      return n
+    }
+
+    /* Logos come in two common shapes: wide wordmarks (1:1 to 8:1) and round
+     * seals/emblems (a winery/farm/brewery crest, roughly square or circular —
+     * width:height near 1:1). Reward both; punish anything approaching hero
+     * dimensions regardless of shape. */
+    const geometryScore = rect => {
+      const area = rect.width * rect.height
+      const ratio = rect.width / Math.max(rect.height, 1)
+      let n = 0
+      if (ratio >= 1 && ratio <= 8) n += 30 // wordmark proportions
+      else if (ratio >= 0.6 && ratio < 1) n += 25 // seal/emblem proportions
+      if (rect.height <= 140) n += 25
+      if (area > MAX_LOGO_AREA) n -= 50 + Math.min(100, area / 20000)
+      return n
+    }
+
+    const rectOf = rect => ({
+      top: Math.round(rect.top),
+      left: Math.round(rect.left),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height)
+    })
+
+    const candidates = []
+
+    // NOT scoped to header/nav and not cut off after the first screenful — a
+    // centered hero emblem (common for wineries, farms, boutique brands) can
+    // sit well below the fold on a tall homepage. Position is still recorded
+    // so a caller can do vision-bbox matching; it just isn't a hard filter
+    // here, since restricting it is exactly what causes misses like this.
+    for (const img of [...document.querySelectorAll('img')].slice(0, 400)) {
+      if (isOurWidget(img)) continue
+      const rect = img.getBoundingClientRect()
+      if (rect.width < 16 || rect.height < 16) continue
+      const src = img.currentSrc || img.src
+      if (!src || src.startsWith('data:')) continue
+      const inHeader = Boolean(img.closest(HEADER_SELECTOR))
+      const named = nameScore(
+        src,
+        img.alt,
+        img.title,
+        img.className,
+        img.id,
+        img.parentElement?.className
+      )
+      const area = rect.width * rect.height
+      // Deliberately lenient: this pool feeds vision-bbox matching, which does
+      // the real discriminating by *looking at the picture*. Only hard-exclude
+      // what's unambiguous — an unnamed, non-header image below a generous
+      // hero-region cutoff, or anything at true hero-photo scale regardless of
+      // position. Everything else rides through for vision to judge; geometry
+      // only shapes its `score` (used for text-fallback ranking, not inclusion).
+      if (area > HERO_AREA_CUTOFF) continue
+      if (!inHeader && named <= 0 && rect.top > 900) continue
+      candidates.push({
+        url: src,
+        kind: 'img',
+        rect: rectOf(rect),
+        area: Math.round(area),
+        score: Math.round(
+          (inHeader ? 80 : 0) +
+            (linksHome(img) ? 70 : 0) +
+            named +
+            geometryScore(rect) -
+            rect.top / 80 -
+            rect.left / 40
+        )
+      })
+    }
+
+    for (const svg of [...document.querySelectorAll('svg')].slice(0, 60)) {
+      if (isOurWidget(svg)) continue
+      if (svg.querySelector('svg')) continue // nested match means we grabbed a container
+      const rect = svg.getBoundingClientRect()
+      if (rect.width < 24 || rect.height < 12) continue
+      if (!isLogoLikeSvg(svg)) continue
+      const inHeader = Boolean(svg.closest(HEADER_SELECTOR))
+      const named = svgNameScore(svg)
+      const shapeScore = geometryScore(rect)
+      // An inline <svg> is never a hero photo (those are always raster), so the
+      // hero-scale exclusion img candidates need doesn't apply here — just keep
+      // it near the top of the page unless it's clearly named/shaped as a mark.
+      if (!inHeader && named <= 0 && shapeScore <= 0 && rect.top > 900) continue
+      if (svg.outerHTML.length > MAX_SVG_BYTES) continue
+      const url = svgToDataUri(svg)
+      if (url.length > MAX_SVG_BYTES * 2) continue
+      candidates.push({
+        url,
+        kind: 'svg',
+        rect: rectOf(rect),
+        area: Math.round(rect.width * rect.height),
+        score: Math.round(
+          (inHeader ? 90 : 40) +
+            named +
+            (linksHome(svg) ? 70 : 0) +
+            shapeScore -
+            rect.top / 80 -
+            rect.left / 40
+        )
+      })
+    }
+
+    for (const { url, weight } of structuredLogos()) {
+      candidates.push({ url, kind: 'ld+json', area: 0, score: weight })
+    }
+
+    const meta = document.querySelector(
+      'meta[property="og:image"], meta[name="twitter:image"]'
+    )
+    const ogImage = meta?.getAttribute('content')
+    if (ogImage) candidates.push({ url: ogImage, kind: 'og', area: 0, score: 5 })
+
+    /* Always present, rarely the best *display* logo (too low-res), but a
+     * strong signal for color specifically — favicons are commonly simplified
+     * to a single dominant brand chip precisely because they render at 16-32px.
+     * kind is tagged distinctly so a caller can prioritize these for color
+     * sampling even when they'd never win as the displayed logoUrl. */
+    const iconHref = document
+      .querySelector('link[rel="apple-touch-icon"], link[rel="apple-touch-icon-precomposed"]')
+      ?.getAttribute('href')
+    if (iconHref) {
+      candidates.push({ url: resolveUrl(iconHref, location.href), kind: 'apple-touch-icon', area: 0, score: 8 })
+    }
+    const faviconHref = document
+      .querySelector('link[rel="icon"], link[rel="shortcut icon"]')
+      ?.getAttribute('href')
+    if (faviconHref) {
+      candidates.push({ url: resolveUrl(faviconHref, location.href), kind: 'favicon', area: 0, score: 6 })
+    }
+
+    const seen = new Set()
+    return candidates
+      .sort((a, b) => b.score - a.score)
+      .filter(c => !seen.has(c.url) && seen.add(c.url))
+      .slice(0, 10)
+  })
+
+  const title = safe(() => {
+    const siteName = document
+      .querySelector('meta[property="og:site_name"]')
+      ?.getAttribute('content')
+    return (siteName || document.title || '').trim().slice(0, 120) || null
+  })
+
+  return {
+    cssVariables: cssVariables || [],
+    computedColors: computedColors || [],
+    themeColor: themeColor || null,
+    fonts: fonts || { body: null, heading: null },
+    logos: logos || [],
+    title: title || null
+  }
+})()

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -23,6 +23,9 @@ class CrawlerConfig:
     # Crawling parameters
     start_urls: List[str] = field(default_factory=list)
     max_depth: int = 3
+    # Hard ceiling on pages visited by the deep crawl. max_depth alone is not a
+    # bound — depth 1 on a site with a 400-link footer is a 400-page crawl.
+    max_pages: int = 100
     batch_size: int = 10
     include_external: bool = False
 
@@ -36,6 +39,10 @@ class CrawlerConfig:
     # Extra wait (seconds) on the first/root fetch so JS anti-bot challenges
     # (e.g. SiteGround's "Robot Challenge Screen") can resolve and reload.
     challenge_wait: int = 12
+    # Wait (seconds) on subsequent pages in the shallow demo scrape. The anti-bot
+    # challenge only fires on first load, and these are fetched concurrently, so
+    # they need far less than the root.
+    subpage_wait: int = 1
 
     # Validation parameters
     expected_chunks: int = 0  # 0 means no validation
@@ -76,7 +83,9 @@ class CrawlerConfig:
     # Summarization parameters
     summary_model_name: str = "gpt-4.1-nano"
     summary_temperature: float = 0.3
-    summary_max_workers: int = 10
+    # gpt-4.1-nano, I/O-bound. At depth 1 x 100 pages this is ~500 calls, and
+    # 10-wide made summarization the second-biggest chunk of wall clock.
+    summary_max_workers: int = 24
 
     # Vector DB parameters
     chunk_id_prefix: str = "web_crawl"
@@ -134,6 +143,12 @@ class CrawlerConfig:
         # Process numeric values
         if "MAX_DEPTH" in os.environ:
             config.max_depth = int(os.environ["MAX_DEPTH"])
+
+        if "MAX_PAGES" in os.environ:
+            config.max_pages = int(os.environ["MAX_PAGES"])
+
+        if "SUBPAGE_WAIT" in os.environ:
+            config.subpage_wait = int(os.environ["SUBPAGE_WAIT"])
 
         if "BATCH_SIZE" in os.environ:
             config.batch_size = int(os.environ["BATCH_SIZE"])

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -39,7 +39,9 @@ async def crawl(config: CrawlerConfig = None):
         sys.setrecursionlimit(10000)
 
     deep_crawl = BFSDeepCrawlStrategy(
-        max_depth=config.max_depth, include_external=config.include_external
+        max_depth=config.max_depth,
+        max_pages=config.max_pages,
+        include_external=config.include_external,
     )
 
     crawler_link_config = CrawlerRunConfig(

--- a/logo_probe.js
+++ b/logo_probe.js
@@ -1,0 +1,151 @@
+/* Lightweight, per-page logo-candidate collector, evaluated on every page
+ * scrape_page.py fetches (homepage + internal links) — not just the homepage.
+ *
+ * brand_probe.js finds a logo from ONE page using selectors: header/nav
+ * membership, alt text, filename. That fails outright on CMSs (Wix, Squarespace)
+ * that don't wrap chrome in semantic <header>/<nav> tags at all.
+ *
+ * This script instead just harvests every plausible image/wordmark near the top
+ * of whatever page it runs on, tagged with its position and identity. The Python
+ * side then looks for the one candidate that recurs across multiple distinct
+ * pages in roughly the same spot — the actual defining property of a logo (it's
+ * the one image that's the same everywhere), independent of any markup
+ * convention. A hero photo or product shot never repeats; a logo always does. */
+(() => {
+  const WIDGET_SELECTOR =
+    '#dialogue-foundry-app, [id*="dialogue-foundry"], [class*="dialogue-foundry"], [data-dialogue-foundry-id]'
+  const isOurWidget = el => Boolean(el.closest(WIDGET_SELECTOR))
+
+  try {
+    window.scrollTo(0, 0)
+  } catch {
+    /* not fatal */
+  }
+
+  const linksHome = el => {
+    const anchor = el.closest('a[href]')
+    if (!anchor) return false
+    try {
+      const href = new URL(anchor.href, location.href)
+      return (
+        href.origin === location.origin &&
+        href.pathname.replace(/\/+$/, '') === ''
+      )
+    } catch {
+      return false
+    }
+  }
+
+  /* Strip resize/query params so the same logo served at different dimensions
+   * on different pages (Wix's /v1/fill/w_864,h_66/... vs w_324,h_191/...) still
+   * groups as one identity. */
+  const normalizeUrlKey = url => {
+    try {
+      const parsed = new URL(url, location.href)
+      return (
+        'img:' +
+        (parsed.origin + parsed.pathname)
+          .replace(/~mv2.*$/, '')
+          .toLowerCase()
+      )
+    } catch {
+      return 'img:' + url
+    }
+  }
+
+  const djb2 = text => {
+    let hash = 5381
+    for (let i = 0; i < text.length; i++) {
+      hash = (hash * 33) ^ text.charCodeAt(i)
+    }
+    return (hash >>> 0).toString(36)
+  }
+
+  /* Bake computed fill/stroke onto a clone so an inline SVG (whose paint often
+   * comes from `var(--token)` or an inherited class) still renders once lifted
+   * out of the page's cascade. */
+  const svgToDataUri = svg => {
+    const clone = svg.cloneNode(true)
+    const originals = [svg, ...svg.querySelectorAll('*')]
+    const clones = [clone, ...clone.querySelectorAll('*')]
+    for (let i = 0; i < originals.length && i < clones.length; i++) {
+      const computed = getComputedStyle(originals[i])
+      const props =
+        originals[i].tagName.toLowerCase() === 'stop'
+          ? ['stop-color']
+          : ['fill', 'stroke']
+      for (const prop of props) {
+        const value = computed.getPropertyValue(prop)
+        if (value && value !== 'none' && !value.includes('var(')) {
+          clones[i].setAttribute(prop, value)
+        }
+      }
+    }
+    clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+    const bytes = new TextEncoder().encode(clone.outerHTML)
+    let binary = ''
+    for (const byte of bytes) binary += String.fromCharCode(byte)
+    return 'data:image/svg+xml;base64,' + btoa(binary)
+  }
+
+  const isLogoLikeSvg = svg =>
+    !svg.querySelector('mask, text, foreignObject') &&
+    Boolean(svg.querySelector('path, polygon, circle, rect'))
+
+  const candidates = []
+  const seenKeys = new Set()
+
+  // Deliberately NOT scoped to header/nav — that selector assumption is exactly
+  // what fails on markup-free CMS builders. Position (near the top) is the only
+  // filter; recurrence across pages does the real discriminating.
+  for (const img of document.querySelectorAll('img')) {
+    if (isOurWidget(img)) continue
+    const rect = img.getBoundingClientRect()
+    if (rect.width < 16 || rect.height < 16) continue
+    if (rect.top > 400) continue
+    const src = img.currentSrc || img.src
+    if (!src || src.startsWith('data:')) continue
+    const key = normalizeUrlKey(src)
+    if (seenKeys.has(key)) continue
+    seenKeys.add(key)
+    candidates.push({
+      key,
+      url: src,
+      kind: 'img',
+      top: Math.round(rect.top),
+      left: Math.round(rect.left),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+      linksHome: linksHome(img)
+    })
+  }
+
+  for (const svg of document.querySelectorAll('svg')) {
+    if (isOurWidget(svg)) continue
+    if (svg.querySelector('svg')) continue // nested match means we grabbed a container
+    const rect = svg.getBoundingClientRect()
+    if (rect.width < 24 || rect.height < 12) continue
+    if (rect.top > 400) continue
+    if (rect.width / Math.max(rect.height, 1) < 1.2) continue
+    if (!isLogoLikeSvg(svg)) continue
+    const markup = svg.outerHTML
+    if (markup.length > 24000) continue
+    // Identity is the raw markup shape, not the baked data URI (which can shift
+    // slightly if computed fill differs subtly across pages).
+    const key = 'svg:' + djb2(markup.replace(/\s+/g, ''))
+    if (seenKeys.has(key)) continue
+    seenKeys.add(key)
+    candidates.push({
+      key,
+      url: svgToDataUri(svg),
+      kind: 'svg',
+      top: Math.round(rect.top),
+      left: Math.round(rect.left),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+      linksHome: linksHome(svg)
+    })
+  }
+
+  return candidates.slice(0, 40)
+})()

--- a/scrape_page.py
+++ b/scrape_page.py
@@ -3,12 +3,16 @@
 Shallow, fast scrape entrypoint for the demo-setup pipeline.
 
 Unlike orchestrator.py (which does a deep crawl, chunks, summarizes, and upserts
-to the vector store), this fetches just the homepage and a few internal pages with
-a real browser (crawl4ai) and prints a JSON payload to stdout:
+to the vector store), this fetches the homepage and a few high-signal internal
+pages with a real browser (crawl4ai) and prints a JSON payload to stdout:
 
     {
       "pages": [{"url": "...", "markdown": "..."}, ...],
-      "homepageHtml": "<rendered HTML of the homepage>"
+      "homepageHtml": "<rendered HTML of the homepage>",
+      "brand": {"cssVariables": [...], "computedColors": [...],
+                "pixelDominantColors": [...], "logos": [...], ...},
+      "screenshot": "<base64 JPEG of the homepage's first ~1600px>",
+      "screenshotWidth": 1200, "screenshotHeight": 1600
     }
 
 The Node demo-setup service spawns this as a subprocess and parses stdout. All
@@ -17,15 +21,73 @@ logs go to stderr so stdout stays pure JSON.
 Reuses the crawler's tuned browser settings (real Chrome channel, stealth,
 fixed UA) so JS-heavy and anti-bot-protected sites render like the deep crawler.
 No LLM content filter is used here — we want the raw rendered markdown/HTML fast.
+
+The `brand` payload comes from brand_probe.js, evaluated inside the settled page.
+Reading getComputedStyle beats regexing the returned HTML: external stylesheets
+(where modern sites keep all their color) never appear in the HTML at all.
 """
 
 import os
+import re
 import sys
 import json
+import base64
 import asyncio
+from collections import Counter
+from io import BytesIO
+from pathlib import Path
+from urllib.parse import urlparse
 
+from PIL import Image
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
 from crawler.config import CrawlerConfig
+
+# Cap the screenshot we hand to the vision model. The nav bar, hero, and primary
+# CTA all live above the fold; everything below is footer noise that costs tokens.
+SCREENSHOT_MAX_HEIGHT = 1600
+SCREENSHOT_MAX_WIDTH = 1200
+SCREENSHOT_JPEG_QUALITY = 80
+
+# Paths whose content actually helps a chat demo answer questions, best first.
+# Without this we scrape whatever the nav happens to link first, which on most
+# sites is a login page and a blog index.
+PATH_PRIORITIES = (
+    (60, re.compile(r"/(about|about-us|our-story|who-we-are)\b")),
+    (55, re.compile(r"/(service|services|what-we-do|solutions|offerings)\b")),
+    (55, re.compile(r"/(product|products|shop|menu|collection)\b")),
+    (50, re.compile(r"/(pricing|prices|rates|packages|plans)\b")),
+    (45, re.compile(r"/(faq|faqs|questions)\b")),
+    (40, re.compile(r"/(contact|contact-us|location|locations|hours|visit)\b")),
+    (25, re.compile(r"/(team|staff|testimonial|review)\b")),
+)
+PATH_PENALTIES = (
+    (-100, re.compile(r"/(login|signin|sign-in|register|cart|checkout|account)\b")),
+    (-80, re.compile(r"/(privacy|terms|cookie|legal|sitemap|accessibility)\b")),
+    (-40, re.compile(r"/(blog|news|press|category|tag|author|archive)/.+")),
+    (-30, re.compile(r"\.(pdf|jpg|jpeg|png|zip|mp4|webp|svg)$")),
+)
+
+PROBE_JS = (Path(__file__).parent / "brand_probe.js").read_text()
+LOGO_PROBE_JS = (Path(__file__).parent / "logo_probe.js").read_text()
+
+# A logo candidate must recur on at least this many distinct pages to count —
+# one page alone gives no cross-page signal to discriminate it from hero art.
+LOGO_MIN_RECURRING_PAGES = 2
+# Position tolerance (px) for "roughly the same spot": logos are pinned in a
+# sticky/static header, so their vertical position barely moves across pages.
+LOGO_MAX_TOP_VARIANCE = 60
+
+# Dominant-color tiling: a flat UI-chrome tile (header bar, button, footer) has
+# near-zero pixel spread; a photo/texture tile doesn't. This threshold is on a
+# 0-255 per-channel min/max spread within one downscaled 8x8 tile.
+DOMINANT_COLOR_TILE_PX = 8
+DOMINANT_COLOR_FLATNESS_THRESHOLD = 20
+DOMINANT_COLOR_MAX_WIDTH = 240
+# Real brand color often lives in the footer or a below-the-fold CTA, not just
+# the hero — so the pixel-color scan looks at the whole page, separately from
+# the smaller crop sent to vision. Capped so a long-scrolling / infinite-scroll
+# page can't blow this up unboundedly.
+DOMINANT_COLOR_MAX_PAGE_HEIGHT = 8000
 
 
 def log(message):
@@ -58,6 +120,44 @@ def _normalize_results(response):
         return [response]
 
 
+def _score_link(href: str) -> int:
+    """Rank an internal link by how likely it is to describe the business."""
+    path = (urlparse(href).path or "/").lower().rstrip("/") + "/"
+    score = 0
+    for weight, pattern in PATH_PRIORITIES:
+        if pattern.search(path):
+            score += weight
+            break
+    for weight, pattern in PATH_PENALTIES:
+        if pattern.search(path):
+            score += weight
+    # Prefer shallow pages; /services beats /services/commercial/roofing/gutters.
+    score -= 5 * max(0, path.count("/") - 2)
+    return score
+
+
+def _select_links(root_result, start_url: str, limit: int) -> list:
+    """Pick the `limit` highest-signal internal links off the homepage."""
+    internal = (getattr(root_result, "links", {}) or {}).get("internal", [])
+    seen = {start_url.rstrip("/")}
+    scored = []
+    for link in internal:
+        href = link.get("href") if isinstance(link, dict) else None
+        if not href:
+            continue
+        href = href.split("#")[0].rstrip("/")
+        if not href or href in seen:
+            continue
+        seen.add(href)
+        score = _score_link(href)
+        if score <= -30:
+            continue
+        scored.append((score, href))
+
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    return [href for _, href in scored[:limit]]
+
+
 def _build_browser_config(config: CrawlerConfig) -> BrowserConfig:
     browser_config = BrowserConfig(
         browser_type=config.browser_type,
@@ -68,6 +168,11 @@ def _build_browser_config(config: CrawlerConfig) -> BrowserConfig:
         text_mode=config.text_mode,
         ignore_https_errors=config.ignore_https_errors,
         user_agent=config.user_agent,
+        # crawl4ai's default (1080x600) is barely taller than a nav bar — most
+        # homepages render their real UI chrome (buttons, footer) below that,
+        # and a short viewport also under-triggers scroll-based lazy loading.
+        viewport_width=1280,
+        viewport_height=1400,
         # crawl4ai prints its own init banner straight to stdout when verbose,
         # which would corrupt the pure-JSON contract this script promises.
         verbose=False,
@@ -88,8 +193,10 @@ def _run_config(config: CrawlerConfig, is_root: bool) -> CrawlerRunConfig:
         exclude_external_images=True,
         verbose=config.verbose,
         # Longer wait on the root fetch so a JS anti-bot challenge can solve.
+        # Subpages reuse the warmed session and never see the challenge, so they
+        # only need enough time for above-the-fold JS to settle.
         delay_before_return_html=(
-            config.challenge_wait if is_root else config.delay_before_return_html
+            config.challenge_wait if is_root else config.subpage_wait
         ),
         magic=config.magic,
         simulate_user=config.simulate_user,
@@ -97,18 +204,381 @@ def _run_config(config: CrawlerConfig, is_root: bool) -> CrawlerRunConfig:
         user_agent=config.user_agent,
         process_iframes=True,
         remove_overlay_elements=True,
-        session_id="scrape_session",
+        # Colors/fonts only need the homepage. The logo probe runs on every page
+        # (root + subpages) — the dedicated logo hunt below needs candidates from
+        # each page to compute cross-page recurrence.
+        js_code=[PROBE_JS, LOGO_PROBE_JS] if is_root else [LOGO_PROBE_JS],
+        # Each subpage gets its own session so they can run concurrently; the
+        # root keeps the shared one it warmed up solving the challenge.
+        session_id="scrape_session" if is_root else None,
     )
+
+
+def _js_results(result) -> list:
+    """crawl4ai's js_execution_result envelope:
+    {"success": bool, "results": [{"success": bool, "result": <ours>}, ...]}
+    one entry per script in the js_code list, in order. Any deviation means a
+    script threw or the page blocked evaluation."""
+    envelope = getattr(result, "js_execution_result", None) or {}
+    return [
+        entry["result"]
+        for entry in envelope.get("results") or []
+        if isinstance(entry, dict) and "result" in entry
+    ]
+
+
+def _extract_probe(result) -> dict:
+    """Pull the brand_probe.js object out of the js_execution_result envelope.
+    Falls back to {} (Node then falls back to HTML parsing) if the probe threw."""
+    for value in _js_results(result):
+        if isinstance(value, dict):
+            return value
+    log(f"Brand probe returned no result (envelope: {str(getattr(result, 'js_execution_result', None))[:200]})")
+    return {}
+
+
+def _extract_logo_candidates(result) -> list:
+    """Pull logo_probe.js's candidate array out of the same envelope."""
+    for value in _js_results(result):
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _group_logo_candidates(candidates_by_page: list, start_url: str) -> dict:
+    """The defining property of a logo, independent of any markup convention:
+    it's the one image that appears in the same spot on every page, while hero
+    photos, product shots, and promos never repeat. Groups per-page candidates
+    (from logo_probe.js) by identity so recurrence across distinct pages can be
+    scored — this is a *signal*, not a filter, since a homepage-only hero-style
+    emblem never gets the chance to recur but can still be the real logo.
+
+    `candidates_by_page` is a list of (page_url, candidate_dict) pairs. Each
+    group keeps one representative rect (preferring the homepage occurrence) so
+    a recurrence-only find can still participate in vision-bbox matching.
+    """
+    groups = {}
+    for page_url, candidate in candidates_by_page:
+        key = candidate["key"]
+        group = groups.setdefault(
+            key,
+            {
+                "url": candidate["url"],
+                "kind": candidate["kind"],
+                "pages": set(),
+                "tops": [],
+                "widths": [],
+                "heights": [],
+                "links_home": 0,
+                "rect": None,
+            },
+        )
+        group["pages"].add(page_url)
+        group["tops"].append(candidate["top"])
+        group["widths"].append(candidate["width"])
+        group["heights"].append(candidate["height"])
+        if candidate.get("linksHome"):
+            group["links_home"] += 1
+        if group["rect"] is None or page_url == start_url:
+            group["rect"] = {
+                "top": candidate["top"],
+                "left": candidate["left"],
+                "width": candidate["width"],
+                "height": candidate["height"],
+            }
+    return groups
+
+
+def _logo_recurrence_score(group: dict) -> int:
+    page_count = len(group["pages"])
+    top_variance = max(group["tops"]) - min(group["tops"])
+    avg_width = sum(group["widths"]) / len(group["widths"])
+    avg_height = sum(group["heights"]) / len(group["heights"])
+    ratio = avg_width / max(avg_height, 1)
+
+    score = page_count * 100
+    score += 40 if group["links_home"] > 0 else 0
+    score += 20 if 1 <= ratio <= 8 else 0  # wordmark proportions
+    score -= min(80, top_variance)  # position drift across pages
+    return round(score)
+
+
+def _normalize_img_key(url: str) -> str:
+    """Mirrors logo_probe.js's normalizeUrlKey so a homepage img candidate (raw
+    URL with resize params) can be matched against recurrence groups (keyed by
+    the same normalized form)."""
+    try:
+        parsed = urlparse(url)
+        base = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+    except ValueError:
+        base = url
+    return "img:" + re.sub(r"~mv2.*$", "", base, flags=re.IGNORECASE).lower()
+
+
+def _apply_logo_recurrence(
+    brand: dict, candidates_by_page: list, start_url: str, page_count: int
+) -> None:
+    """Cross-check brand_probe.js's homepage candidates (which carry real
+    position data, needed for vision-bbox matching) against multi-page
+    recurrence, and fold in any recurring candidate the homepage probe missed
+    entirely — without discarding position data on the ones it did find."""
+    groups = _group_logo_candidates(candidates_by_page, start_url)
+    logos = brand.get("logos") or []
+
+    matched_keys = set()
+    for logo in logos:
+        if logo.get("kind") != "img":
+            continue
+        key = _normalize_img_key(logo["url"])
+        group = groups.get(key)
+        if group and len(group["pages"]) >= LOGO_MIN_RECURRING_PAGES:
+            matched_keys.add(key)
+            recurring_pages = len(group["pages"])
+            logo["score"] = logo.get("score", 0) + recurring_pages * 30
+            logo["recurringPages"] = recurring_pages
+
+    for key, group in groups.items():
+        if key in matched_keys or len(group["pages"]) < LOGO_MIN_RECURRING_PAGES:
+            continue
+        logos.append(
+            {
+                "url": group["url"],
+                "kind": group["kind"],
+                "score": _logo_recurrence_score(group),
+                "recurringPages": len(group["pages"]),
+                "rect": group["rect"],
+            }
+        )
+
+    if logos:
+        log(
+            f"Logo recurrence: checked against {page_count} pages scraped, "
+            f"{sum(1 for l in logos if l.get('recurringPages'))} candidate(s) recur"
+        )
+    brand["logos"] = sorted(logos, key=lambda l: l.get("score", 0), reverse=True)[:10]
+
+
+def _saturation_lightness(r: int, g: int, b: int) -> tuple:
+    mx, mn = max(r, g, b) / 255, min(r, g, b) / 255
+    lightness = (mx + mn) / 2
+    if mx == mn:
+        return 0.0, lightness
+    delta = mx - mn
+    saturation = delta / (2 - mx - mn) if lightness > 0.5 else delta / (mx + mn)
+    return saturation, lightness
+
+
+def _is_brandworthy_rgb(r: int, g: int, b: int) -> bool:
+    """White/near-white and near-black are almost always page background or
+    body text, not a chosen brand color — and a page's background is by
+    definition its single largest flat region, so without this the dominant-
+    color scan would just rediscover "the page is white" every time."""
+    saturation, lightness = _saturation_lightness(r, g, b)
+    return saturation >= 0.15 and 0.08 <= lightness <= 0.9
+
+
+def _largest_connected_blob(grid: dict, start: tuple, visited: set) -> int:
+    """4-connected flood fill; returns the size (tile count) of the connected
+    region of same-bucket tiles containing `start`."""
+    if start in visited:
+        return 0
+    bucket = grid[start]
+    stack = [start]
+    size = 0
+    while stack:
+        cell = stack.pop()
+        if cell in visited or grid.get(cell) != bucket:
+            continue
+        visited.add(cell)
+        size += 1
+        x, y = cell
+        stack.extend([(x + 1, y), (x - 1, y), (x, y + 1), (x, y - 1)])
+    return size
+
+
+def _dominant_flat_colors(png_bytes: bytes, max_candidates: int = 8) -> list:
+    """What a designer's eye does instinctively: which flat color visually
+    dominates the page? DOM sampling (brand_probe.js's computedColors) weighs
+    every styled element roughly equally, so a handful of small buttons can
+    lose to dozens of plain text links. This instead looks at the actual
+    rendered pixels directly.
+
+    A local per-tile variance filter alone isn't enough: a smooth gradient sky
+    behind a hero photo has near-zero variance *within* any single small tile,
+    so it reads as "flat" too, and a gradient can easily cover more pixels than
+    a small solid-colored button. The real discriminator is contiguity — a
+    genuine UI element (header bar, button, footer) is one large *contiguous*
+    block of near-identical color, while a gradient's matching-quantized tiles
+    are scattered along a thin, continuously-drifting band. So: tile the image,
+    quantize each flat tile's color, then flood-fill same-color tiles into
+    connected blobs and rank by the size of the single largest blob per color —
+    not by how many scattered tiles share that color."""
+    image = Image.open(BytesIO(png_bytes)).convert("RGB")
+    if image.width > DOMINANT_COLOR_MAX_WIDTH:
+        ratio = DOMINANT_COLOR_MAX_WIDTH / image.width
+        image = image.resize(
+            (DOMINANT_COLOR_MAX_WIDTH, max(1, int(image.height * ratio))),
+            Image.BILINEAR,
+        )
+
+    tile = DOMINANT_COLOR_TILE_PX
+    grid = {}
+    tile_count = 0
+    for ty, y in enumerate(range(0, image.height - tile + 1, tile)):
+        for tx, x in enumerate(range(0, image.width - tile + 1, tile)):
+            extrema = image.crop((x, y, x + tile, y + tile)).getextrema()
+            if max(hi - lo for lo, hi in extrema) > DOMINANT_COLOR_FLATNESS_THRESHOLD:
+                continue  # textured — not a candidate UI element
+            r, g, b = (round((lo + hi) / 2) for lo, hi in extrema)
+            if not _is_brandworthy_rgb(r, g, b):
+                continue
+            # Quantize just enough to group anti-aliased shades of a TRUE flat
+            # color together. A coarser bucket would also swallow a *slowly
+            # drifting* gradient (a hero photo's sky) into one bucket across a
+            # wide contiguous span, letting it pass the blob-size check below
+            # even though it's clearly not solid UI chrome. A real flat
+            # rectangle has zero drift regardless of bucket size, so tightening
+            # this specifically penalizes gradients without hurting real matches.
+            grid[(tx, ty)] = (r // 6 * 6, g // 6 * 6, b // 6 * 6)
+            tile_count += 1
+
+    if not tile_count:
+        return []
+
+    visited: set = set()
+    largest_blob = Counter()
+    for cell in list(grid.keys()):
+        if cell in visited:
+            continue
+        size = _largest_connected_blob(grid, cell, visited)
+        bucket = grid[cell]
+        largest_blob[bucket] = max(largest_blob[bucket], size)
+
+    # A genuine UI element needs to span a real chunk of the page, not a couple
+    # of stray matching tiles — otherwise noise from anti-aliased edges creeps
+    # back in as "the biggest blob" on pages with no solid chrome at all.
+    min_blob_tiles = max(4, tile_count // 40)
+    ranked = [
+        (bucket, size)
+        for bucket, size in largest_blob.most_common()
+        if size >= min_blob_tiles
+    ]
+
+    return [
+        {
+            "hex": "#{:02x}{:02x}{:02x}".format(*bucket),
+            "coverage": round(size / tile_count, 3),
+        }
+        for bucket, size in ranked[:max_candidates]
+    ]
+
+
+def _shrink_screenshot(png_bytes: bytes) -> dict:
+    """Crop to the fold, downscale, JPEG-encode. Returns base64 (no data: prefix)
+    plus the final pixel dimensions, so a percentage-based vision bounding box
+    can be converted back to page pixel coordinates precisely."""
+    image = Image.open(BytesIO(png_bytes)).convert("RGB")
+    if image.height > SCREENSHOT_MAX_HEIGHT:
+        image = image.crop((0, 0, image.width, SCREENSHOT_MAX_HEIGHT))
+    if image.width > SCREENSHOT_MAX_WIDTH:
+        ratio = SCREENSHOT_MAX_WIDTH / image.width
+        image = image.resize(
+            (SCREENSHOT_MAX_WIDTH, int(image.height * ratio)), Image.LANCZOS
+        )
+    buffer = BytesIO()
+    image.save(buffer, format="JPEG", quality=SCREENSHOT_JPEG_QUALITY)
+    return {
+        "b64": base64.b64encode(buffer.getvalue()).decode("utf-8"),
+        "width": image.width,
+        "height": image.height,
+    }
+
+
+def _make_screenshot_hook(state: dict):
+    """Captures two different screenshots off the same settled page:
+    - A small fold-height crop, shown to the vision model — keeps LLM image
+      tokens (and therefore cost/latency) down, and header + hero is where
+      logos and nav colors live anyway.
+    - A full-page capture used only for the deterministic pixel-color scan,
+      which never touches the LLM so its size doesn't cost anything extra.
+      Real brand color often concentrates in a footer band or a below-the-fold
+      CTA that the fold crop alone would miss entirely.
+
+    Runs in `before_retrieve_html`, which fires after js_code has run and
+    scrolled us back to the top, but before the HTML is serialized."""
+
+    async def hook(page, context=None, **kwargs):
+        if state.get("screenshot") is not None:
+            return page  # subpage fetch; we already have the homepage shot
+        try:
+            height = await page.evaluate("document.documentElement.scrollHeight")
+            width = await page.evaluate("document.documentElement.scrollWidth")
+            clip = {
+                "x": 0,
+                "y": 0,
+                "width": min(int(width) or SCREENSHOT_MAX_WIDTH, 1600),
+                "height": min(int(height) or SCREENSHOT_MAX_HEIGHT, SCREENSHOT_MAX_HEIGHT),
+            }
+            raw = await page.screenshot(clip=clip, type="png")
+            shrunk = _shrink_screenshot(raw)
+            state["screenshot"] = shrunk["b64"]
+            state["screenshotWidth"] = shrunk["width"]
+            state["screenshotHeight"] = shrunk["height"]
+            log(f"Captured screenshot ({len(shrunk['b64'])} b64 chars)")
+        except Exception as error:  # noqa: BLE001 - screenshot is best-effort
+            log(f"Screenshot failed: {error}")
+            state["screenshot"] = ""
+            state["pixelColors"] = []
+            return page
+
+        try:
+            full_page_raw = await page.screenshot(full_page=True, type="png")
+            image = Image.open(BytesIO(full_page_raw))
+            if image.height > DOMINANT_COLOR_MAX_PAGE_HEIGHT:
+                buffer = BytesIO()
+                image.crop((0, 0, image.width, DOMINANT_COLOR_MAX_PAGE_HEIGHT)).save(
+                    buffer, format="PNG"
+                )
+                full_page_raw = buffer.getvalue()
+            state["pixelColors"] = _dominant_flat_colors(full_page_raw)
+            log(f"{len(state['pixelColors'])} dominant flat color(s) from full page")
+        except Exception as error:  # noqa: BLE001 - fall back to the fold crop
+            log(f"Full-page capture failed ({error}); scanning fold crop only")
+            state["pixelColors"] = _dominant_flat_colors(raw)
+        return page
+
+    return hook
+
+
+async def _scrape_one(crawler, config, href):
+    """Fetch a single subpage. Never raises — a dead link shouldn't kill the run."""
+    try:
+        log(f"Scraping internal page: {href}")
+        results = _normalize_results(
+            await crawler.arun(href, config=_run_config(config, False))
+        )
+        if results:
+            return {
+                "url": href,
+                "markdown": _markdown_str(results[0]),
+                "logoCandidates": _extract_logo_candidates(results[0]),
+            }
+    except Exception as error:  # noqa: BLE001 - best effort per page
+        log(f"Failed to scrape {href}: {error}")
+    return None
 
 
 async def scrape(start_url: str, max_pages: int) -> dict:
     config = CrawlerConfig.from_environment()
     browser_config = _build_browser_config(config)
 
-    pages = []
-    homepage_html = ""
+    state = {"screenshot": None}
 
     async with AsyncWebCrawler(config=browser_config) as crawler:
+        crawler.crawler_strategy.set_hook(
+            "before_retrieve_html", _make_screenshot_hook(state)
+        )
+
         log(f"Scraping homepage: {start_url}")
         response = await crawler.arun(start_url, config=_run_config(config, True))
         results = _normalize_results(response)
@@ -117,32 +587,45 @@ async def scrape(start_url: str, max_pages: int) -> dict:
 
         root = results[0]
         homepage_html = getattr(root, "html", "") or ""
-        pages.append({"url": start_url, "markdown": _markdown_str(root)})
+        brand = _extract_probe(root)
+        pages = [{"url": start_url, "markdown": _markdown_str(root)}]
+        logo_candidates_by_page = [
+            (start_url, candidate) for candidate in _extract_logo_candidates(root)
+        ]
 
-        # Optionally scrape a few internal links for richer content analysis.
+        # Fetch the highest-signal internal pages concurrently. Doing this
+        # sequentially meant every page paid the full delay_before_return_html
+        # in series, which is where the old ~3min homepage-only scrape went.
         if max_pages > 1:
-            internal = (getattr(root, "links", {}) or {}).get("internal", [])
-            seen = {start_url}
-            for link in internal:
-                href = link.get("href") if isinstance(link, dict) else None
-                if not href or href in seen:
+            links = _select_links(root, start_url, max_pages - 1)
+            fetched = await asyncio.gather(
+                *(_scrape_one(crawler, config, href) for href in links)
+            )
+            for page in fetched:
+                if not page:
                     continue
-                seen.add(href)
-                log(f"Scraping internal page: {href}")
-                try:
-                    sub = _normalize_results(
-                        await crawler.arun(href, config=_run_config(config, False))
-                    )
-                    if sub:
-                        pages.append(
-                            {"url": href, "markdown": _markdown_str(sub[0])}
-                        )
-                except Exception as error:  # noqa: BLE001 - best effort per page
-                    log(f"Failed to scrape {href}: {error}")
-                if len(pages) >= max_pages:
-                    break
+                pages.append({"url": page["url"], "markdown": page["markdown"]})
+                logo_candidates_by_page.extend(
+                    (page["url"], candidate)
+                    for candidate in page.get("logoCandidates") or []
+                )
 
-    return {"pages": pages, "homepageHtml": homepage_html}
+        # Dedicated logo hunt: cross-check the homepage probe's position-aware
+        # candidates against multi-page recurrence (the image/wordmark that
+        # repeats across distinct pages in a consistent spot is almost certainly
+        # the logo, regardless of markup convention), without discarding the
+        # position data a vision-bbox match needs downstream.
+        _apply_logo_recurrence(brand, logo_candidates_by_page, start_url, len(pages))
+        brand["pixelDominantColors"] = state.get("pixelColors") or []
+
+    return {
+        "pages": pages,
+        "homepageHtml": homepage_html,
+        "brand": brand,
+        "screenshot": state.get("screenshot") or "",
+        "screenshotWidth": state.get("screenshotWidth") or 0,
+        "screenshotHeight": state.get("screenshotHeight") or 0,
+    }
 
 
 def main():
@@ -151,7 +634,7 @@ def main():
         log("Usage: python scrape_page.py <url>  (or set SCRAPE_URL)")
         sys.exit(1)
 
-    max_pages = int(os.getenv("SCRAPE_MAX_PAGES", "5"))
+    max_pages = int(os.getenv("SCRAPE_MAX_PAGES", "8"))
 
     try:
         payload = asyncio.run(scrape(start_url, max_pages))


### PR DESCRIPTION
## Summary
- Replace guessing brand color/logo from static HTML (regex over inline styles) with a live-DOM probe (`brand_probe.js`) run inside crawl4ai's browser: CSS custom properties (union of authored `:root` rules + a fixed list of conventional names, since cross-origin stylesheets block `cssRules` access), computed styles on brand-bearing elements weighted by usage count × rendered area, favicon/apple-touch-icon collection, and structured-data (`ld+json`) logo extraction.
- Logo candidates carry on-page `rect` (position) so `demo-setup`'s vision call can localize the real logo visually and match it back to a concrete DOM asset by screen position, instead of picking an index from a text-described list (which was missing pictorial marks/emblems in favor of text banners).
- Adds pixel-level dominant-color sampling from a full-page screenshot (`_dominant_flat_colors` in `scrape_page.py`): tiles the image, filters flat (non-gradient) tiles, then flood-fills same-quantized-color tiles into connected components so a smooth hero-photo gradient can't masquerade as solid UI chrome just because a coarse quantization bucket happens to span it.
- Adds cross-page logo recurrence detection (`logo_probe.js`, run on every scraped page): the same asset recurring in the same relative position across multiple distinct pages is a strong logo-identity signal independent of any CSS/markup convention.
- Raises crawl depth (`MAX_DEPTH` 0→1) and page cap (new `MAX_PAGES`, default 100), and parallelizes subpage scraping (was sequential, each paying a fixed `delay_before_return_html`) to keep the deeper crawl within the existing ~8 minute budget.
- Fixes the screenshot viewport: crawl4ai's default viewport (1080×600) was cutting off most of the page and preventing scroll-triggered lazy-loaded content from ever rendering.

## Test plan
- [x] Ran `scrape_page.py` standalone against multiple real small-business sites (Wix, Squarespace, Shopify, custom-built) and confirmed detected colors/logos against the live pages
- [x] Verified via `demo-setup`'s harness that the full pipeline (this scraper → brand detection → widget config) produces correct results end-to-end