### PR TITLE
fix: cap unbounded content-fetch phase, add LLM timeout/chunking, unbuffered logs

### DIFF
--- a/crawler/config.py
+++ b/crawler/config.py
@@ -75,6 +75,9 @@ class CrawlerConfig:
     """
     chunk_token_threshold: int = 400
     overlap_rate: float = 0.2
+    # Per-request ceiling (seconds) on the content-filter LLM call. Passed
+    # through to litellm.completion via LLMContentFilter's extra_args.
+    llm_timeout: int = 30
 
     # Chunking parameters
     embedding_model_name: str = "text-embedding-3-small"
@@ -242,6 +245,9 @@ class CrawlerConfig:
 
         if "LLM_INSTRUCTION" in os.environ:
             config.llm_instruction = os.environ["LLM_INSTRUCTION"]
+
+        if "LLM_TIMEOUT" in os.environ:
+            config.llm_timeout = int(os.environ["LLM_TIMEOUT"])
 
         if "EXCLUDE_HIDDEN_ELEMENTS" in os.environ:
             config.exclude_hidden_elements = os.environ[

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -76,6 +76,14 @@ async def crawl(config: CrawlerConfig = None):
     content_filter = LLMContentFilter(
         llm_config=openai_config,
         instruction=config.llm_instruction,
+        # Without these, LLMContentFilter defaults to chunk_token_threshold=1e9
+        # (the whole page sent as one prompt) and no per-call timeout — a
+        # single slow/rate-limited response then blocks the entire batch with
+        # no way out, since filter_content() runs synchronously inside
+        # crawl4ai's async pipeline (see crawl_url below).
+        chunk_token_threshold=config.chunk_token_threshold,
+        overlap_rate=config.overlap_rate,
+        extra_args={"timeout": config.llm_timeout},
         verbose=config.verbose,
     )
 
@@ -243,9 +251,18 @@ async def crawl(config: CrawlerConfig = None):
                 print(f"Error crawling {url}: {e}")
                 return []
 
-        # Process URLs in batches
+        # Process URLs in batches. unique_links is every internal link found
+        # across all pages visited in the link-discovery phase above — on a
+        # site with a large nav/footer this can be far larger than max_pages,
+        # even though that phase itself was correctly bounded to max_pages.
+        # Cap here too so content-fetch work stays within the same budget.
         batch_size = config.batch_size
-        url_list = list(unique_links)
+        url_list = list(unique_links)[: config.max_pages]
+        if len(unique_links) > config.max_pages:
+            print(
+                f"Capping content crawl to {config.max_pages} of "
+                f"{len(unique_links)} unique links found (MAX_PAGES)"
+            )
         total_batches = (len(url_list) + batch_size - 1) // batch_size
 
         print(f"Processing URLs in {total_batches} batches of {batch_size}")

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -14,6 +14,13 @@ from summary import summarize_content
 from vectordb.upload import upload_chunks
 from crawler.config import CrawlerConfig
 
+# A piped (non-tty) stdout is block-buffered by default — plain print()
+# calls throughout this codebase could sit unflushed for 10+ minutes during
+# a slow crawl, hiding real progress from whatever spawned this process
+# (demo-setup pipes stdout straight into its own logger).
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
 # Create logs directory if it doesn't exist
 Path("logs").mkdir(exist_ok=True)
 


### PR DESCRIPTION
## Summary
While debugging why apple.com's demo crawl (dialogue-foundry, `MAX_PAGES=25`) was taking 30+ minutes and getting killed/retried, found three compounding issues in `crawl()`:

- **Unbounded phase 2**: `unique_links` collects every internal link found across all pages visited during phase 1's link-discovery BFS, with no cap. `MAX_PAGES` only bounded phase 1 — a site with a large nav/footer (apple.com) can push phase 2's content-fetch into hundreds of pages despite `MAX_PAGES=25`. Now capped to `config.max_pages`.
- **No timeout / no chunking on the LLM content filter**: `LLMContentFilter` was constructed without `chunk_token_threshold` or `overlap_rate`, so it silently fell back to crawl4ai's internal default (~1e9 tokens) instead of the already-configured `400` — each page's entire content went through as one giant unchunked prompt. It also had no per-call timeout: `filter_content()` runs synchronously inside crawl4ai's async pipeline, so a single slow/rate-limited OpenAI call could block the whole batch indefinitely (asyncio.gather doesn't help since nothing yields). Now wires both config values plus a new `LLM_TIMEOUT` (default 30s) via `extra_args`, which crawl4ai forwards straight to `litellm.completion()`.
- **Silent progress due to output buffering**: plain `print()`s throughout this codebase go to a block-buffered pipe when run as a subprocess (not a TTY) — a 20+ minute stretch of real crawl work showed up as total silence in the parent process's logs, making a slow crawl indistinguishable from a hang. `orchestrator.py` now reconfigures stdout/stderr to line-buffered on startup.

## Test plan
- [x] `python3 -m py_compile` on all changed files
- [x] Smoke-tested `LLMContentFilter(chunk_token_threshold=400, overlap_rate=0.2, extra_args={"timeout": 30})` constructs correctly
- [ ] Re-run a crawl against apple.com (or another large site) and confirm it completes within the 30-min `CRAWL_TIMEOUT_MS` window, with visible incremental progress in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)