### PR TITLE
feat(brand-probe): collect structured-data logos and quota the candidate pool

### DIFF
--- a/brand_probe.js
+++ b/brand_probe.js
@@ -321,6 +321,22 @@
    * `currentSrc` resolves srcset and lazy-loaded images, which reading `src`
    * misses. Inline <svg> logos (Stripe, Vercel, most modern sites) have no URL
    * at all, so serialize them to a data: URI — the widget renders that fine. */
+  /* Which signal family each candidate kind comes from. Publisher-declared
+   * images ('structured') are collected and quota'd separately from things we
+   * inferred by walking the DOM, because the two can't be ranked against each
+   * other by score — see the quota at the end of the logos block. */
+  const SOURCE_CLASS = {
+    'ld+json': 'structured',
+    og: 'structured',
+    twitter: 'structured',
+    tile: 'structured',
+    manifest: 'structured',
+    'apple-touch-icon': 'structured',
+    favicon: 'structured',
+    img: 'dom',
+    svg: 'dom'
+  }
+
   const HEADER_PARTS = [
     'header',
     'nav',
@@ -428,13 +444,24 @@
 
   /* Authoritative when present: schema.org Organization.logo. Wix, Shopify and
    * most CMSs emit it, and it survives hashed filenames that name-scoring can't
-   * read. */
+   * read. `image` is only taken off an Organization-ish node — on a Product or
+   * Article node it's a product shot or article hero, not the brand's logo. */
+  const ORGANIZATION_TYPES =
+    /^(Organization|Corporation|LocalBusiness|OnlineBusiness|NewsMediaOrganization|EducationalOrganization|GovernmentOrganization|NGO|PerformingGroup|SportsOrganization|Restaurant|Store|Brand|WebSite)$/i
+  const isOrganizationNode = node => {
+    const type = node['@type']
+    const types = Array.isArray(type) ? type : [type]
+    return types.some(t => typeof t === 'string' && ORGANIZATION_TYPES.test(t))
+  }
+
   const structuredLogos = () => {
     const found = []
     const visit = node => {
       if (!node || typeof node !== 'object') return
       if (Array.isArray(node)) return node.forEach(visit)
-      for (const key of ['logo', 'logoUrl', 'image']) {
+      const organization = isOrganizationNode(node)
+      const keys = organization ? ['logo', 'logoUrl', 'image'] : ['logo', 'logoUrl']
+      for (const key of keys) {
         const value = node[key]
         const url = typeof value === 'string' ? value : value?.url
         if (typeof url === 'string' && /^https?:/.test(url)) {
@@ -594,11 +621,31 @@
       candidates.push({ url, kind: 'ld+json', area: 0, score: weight })
     }
 
-    const meta = document.querySelector(
-      'meta[property="og:image"], meta[name="twitter:image"]'
-    )
-    const ogImage = meta?.getAttribute('content')
-    if (ogImage) candidates.push({ url: ogImage, kind: 'og', area: 0, score: 5 })
+    /* Publisher-declared images. og:image is frequently a hero/marketing shot
+     * rather than a mark, so it cannot be trusted outright — but it's often the
+     * *only* clean signal on sites whose header logo is an inline SVG glyph
+     * (apple.com serves its real mark here as open_graph_logo.png). Emit it as
+     * a candidate and let the vision step decide by looking at it. */
+    const ogImage = document
+      .querySelector('meta[property="og:image"], meta[name="og:image"]')
+      ?.getAttribute('content')
+    if (ogImage) {
+      candidates.push({ url: resolveUrl(ogImage, location.href), kind: 'og', area: 0, score: 5 })
+    }
+    const twitterImage = document
+      .querySelector('meta[name="twitter:image"], meta[property="twitter:image"]')
+      ?.getAttribute('content')
+    if (twitterImage) {
+      candidates.push({ url: resolveUrl(twitterImage, location.href), kind: 'twitter', area: 0, score: 4 })
+    }
+
+    /* Windows tile image — brand-owned, usually the mark on a solid tile. */
+    const tileImage = document
+      .querySelector('meta[name="msapplication-TileImage"]')
+      ?.getAttribute('content')
+    if (tileImage) {
+      candidates.push({ url: resolveUrl(tileImage, location.href), kind: 'tile', area: 0, score: 7 })
+    }
 
     /* Always present, rarely the best *display* logo (too low-res), but a
      * strong signal for color specifically — favicons are commonly simplified
@@ -619,10 +666,22 @@
     }
 
     const seen = new Set()
-    return candidates
+    const deduped = candidates
       .sort((a, b) => b.score - a.score)
       .filter(c => !seen.has(c.url) && seen.add(c.url))
-      .slice(0, 10)
+      .map(c => ({ ...c, sourceClass: SOURCE_CLASS[c.kind] || 'dom' }))
+
+    /* Quota by source class rather than taking the global top-N by score.
+     * Scores from different signal families aren't commensurable — a
+     * publisher-declared logo scores 120 while a header <svg> scores 320, and
+     * neither number means the same thing. Score-sorting therefore lets one
+     * noisy family evict every other, which is exactly how apple.com's real
+     * mark got pushed out by nav-glyph candidates. Guarantee slots per family
+     * instead; the vision step downstream does the actual discriminating by
+     * looking at the images. */
+    const take = (sourceClass, limit) =>
+      deduped.filter(c => c.sourceClass === sourceClass).slice(0, limit)
+    return [...take('structured', 5), ...take('dom', 7)]
   })
 
   const title = safe(() => {
@@ -632,12 +691,23 @@
     return (siteName || document.title || '').trim().slice(0, 120) || null
   })
 
+  /* The manifest's icons are brand-owned and high-res, but reading them means
+   * fetching and parsing JSON — this probe is synchronous, so hand the URL to
+   * the Python side and let it resolve the icons into extra candidates. */
+  const manifestHref = safe(() => {
+    const href = document
+      .querySelector('link[rel="manifest"]')
+      ?.getAttribute('href')
+    return href ? resolveUrl(href, location.href) : null
+  })
+
   return {
     cssVariables: cssVariables || [],
     computedColors: computedColors || [],
     themeColor: themeColor || null,
     fonts: fonts || { body: null, heading: null },
     logos: logos || [],
+    manifestHref: manifestHref || null,
     title: title || null
   }
 })()

--- a/scrape_page.py
+++ b/scrape_page.py
@@ -36,7 +36,8 @@ import asyncio
 from collections import Counter
 from io import BytesIO
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
 
 from PIL import Image
 from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
@@ -245,6 +246,63 @@ def _extract_logo_candidates(result) -> list:
     return []
 
 
+# The manifest's icons are brand-owned and usually high-res. brand_probe.js
+# can't read them (it's synchronous and they live behind a JSON fetch), so it
+# hands us the URL instead.
+MANIFEST_TIMEOUT_SECONDS = 5
+MANIFEST_MAX_ICONS = 2
+
+
+def _icon_pixels(icon: dict) -> int:
+    """Largest declared size, e.g. "48x48 96x96" -> 9216. 'any' (vector) wins."""
+    sizes = str(icon.get("sizes") or "")
+    if "any" in sizes.lower():
+        return 10**9
+    best = 0
+    for token in sizes.split():
+        match = re.fullmatch(r"(\d+)x(\d+)", token.strip(), flags=re.IGNORECASE)
+        if match:
+            best = max(best, int(match.group(1)) * int(match.group(2)))
+    return best
+
+
+def _manifest_logo_candidates(manifest_href: str, start_url: str) -> list:
+    """Fetch the web app manifest and return its largest icons as candidates.
+    Best-effort: any failure just yields nothing."""
+    if not manifest_href:
+        return []
+    try:
+        request = Request(
+            manifest_href, headers={"User-Agent": CrawlerConfig().user_agent}
+        )
+        with urlopen(request, timeout=MANIFEST_TIMEOUT_SECONDS) as response:
+            manifest = json.loads(response.read().decode("utf-8", errors="replace"))
+    except Exception as error:  # noqa: BLE001 - a missing manifest isn't fatal
+        log(f"Manifest fetch failed ({manifest_href}): {error}")
+        return []
+
+    icons = manifest.get("icons")
+    if not isinstance(icons, list):
+        return []
+
+    usable = [icon for icon in icons if isinstance(icon, dict) and icon.get("src")]
+    usable.sort(key=_icon_pixels, reverse=True)
+    candidates = []
+    for icon in usable[:MANIFEST_MAX_ICONS]:
+        candidates.append(
+            {
+                "url": urljoin(manifest_href, str(icon["src"])),
+                "kind": "manifest",
+                "sourceClass": "structured",
+                "area": 0,
+                "score": 9,
+            }
+        )
+    if candidates:
+        log(f"Manifest contributed {len(candidates)} logo candidate(s)")
+    return candidates
+
+
 def _group_logo_candidates(candidates_by_page: list, start_url: str) -> dict:
     """The defining property of a logo, independent of any markup convention:
     it's the one image that appears in the same spot on every page, while hero
@@ -315,13 +373,21 @@ def _normalize_img_key(url: str) -> str:
     return "img:" + re.sub(r"~mv2.*$", "", base, flags=re.IGNORECASE).lower()
 
 
+# Per-family slots in the final candidate pool handed to vision. Scores across
+# families aren't commensurable — a recurrence group scores page_count * 100
+# (820 on an 8-page scrape) while a real header mark scores ~200 on geometry —
+# so a global sort lets one family evict all others. That is precisely how
+# apple.com's logo lost its slot to eight "recurring" nav glyphs. Quota instead;
+# vision does the discriminating by looking at the rendered candidates.
+LOGO_POOL_QUOTA = (("structured", 5), ("dom", 5), ("recurrence", 3))
+
+
 def _apply_logo_recurrence(
     brand: dict, candidates_by_page: list, start_url: str, page_count: int
 ) -> None:
-    """Cross-check brand_probe.js's homepage candidates (which carry real
-    position data, needed for vision-bbox matching) against multi-page
-    recurrence, and fold in any recurring candidate the homepage probe missed
-    entirely — without discarding position data on the ones it did find."""
+    """Cross-check brand_probe.js's homepage candidates against multi-page
+    recurrence, fold in any recurring candidate the homepage probe missed
+    entirely, then quota the pool by signal family."""
     groups = _group_logo_candidates(candidates_by_page, start_url)
     logos = brand.get("logos") or []
 
@@ -337,13 +403,19 @@ def _apply_logo_recurrence(
             logo["score"] = logo.get("score", 0) + recurring_pages * 30
             logo["recurringPages"] = recurring_pages
 
+    # Recurrence groups whose URL already appears in the pool are the same asset
+    # seen a second way — annotate the existing entry rather than duplicating it.
+    existing_urls = {logo["url"] for logo in logos}
     for key, group in groups.items():
         if key in matched_keys or len(group["pages"]) < LOGO_MIN_RECURRING_PAGES:
+            continue
+        if group["url"] in existing_urls:
             continue
         logos.append(
             {
                 "url": group["url"],
                 "kind": group["kind"],
+                "sourceClass": "recurrence",
                 "score": _logo_recurrence_score(group),
                 "recurringPages": len(group["pages"]),
                 "rect": group["rect"],
@@ -355,7 +427,20 @@ def _apply_logo_recurrence(
             f"Logo recurrence: checked against {page_count} pages scraped, "
             f"{sum(1 for l in logos if l.get('recurringPages'))} candidate(s) recur"
         )
-    brand["logos"] = sorted(logos, key=lambda l: l.get("score", 0), reverse=True)[:10]
+
+    ranked = sorted(logos, key=lambda l: l.get("score", 0), reverse=True)
+    pool = []
+    for source_class, limit in LOGO_POOL_QUOTA:
+        taken = [l for l in ranked if l.get("sourceClass", "dom") == source_class]
+        pool.extend(taken[:limit])
+    log(
+        "Logo pool: "
+        + ", ".join(
+            f"{source_class}={sum(1 for l in pool if l.get('sourceClass', 'dom') == source_class)}"
+            for source_class, _ in LOGO_POOL_QUOTA
+        )
+    )
+    brand["logos"] = pool
 
 
 def _saturation_lightness(r: int, g: int, b: int) -> tuple:
@@ -610,11 +695,18 @@ async def scrape(start_url: str, max_pages: int) -> dict:
                     for candidate in page.get("logoCandidates") or []
                 )
 
+        # Publisher-declared icons the synchronous probe couldn't fetch itself.
+        manifest_logos = _manifest_logo_candidates(
+            brand.get("manifestHref") or "", start_url
+        )
+        if manifest_logos:
+            brand["logos"] = (brand.get("logos") or []) + manifest_logos
+
         # Dedicated logo hunt: cross-check the homepage probe's position-aware
         # candidates against multi-page recurrence (the image/wordmark that
         # repeats across distinct pages in a consistent spot is almost certainly
-        # the logo, regardless of markup convention), without discarding the
-        # position data a vision-bbox match needs downstream.
+        # the logo, regardless of markup convention), then quota the pool so no
+        # single signal family can evict the others.
         _apply_logo_recurrence(brand, logo_candidates_by_page, start_url, len(pages))
         brand["pixelDominantColors"] = state.get("pixelColors") or []
 


### PR DESCRIPTION
## Why

apple.com's demo shipped a **"TV & Home" nav glyph** as its logo — again, after the last fix. Root cause was never in selection; the vision step correctly answered "none of these." The real Apple mark had been **evicted from the candidate pool before vision ever saw it.**

Two compounding bugs:

1. **Recurrence flooding.** `_apply_logo_recurrence` scored cross-page groups at `page_count * 100`, then took the global top 10. At the production page count (8), every nav glyph — which by definition recurs on every page — scored **820**, and the groups evicted every homepage candidate, including the real 14×44 Apple mark at 196. The earlier fix passed verification only because it was tested at `SCRAPE_MAX_PAGES=3`, where groups top out at 320. That was the testing mistake.
2. **Scores across signal families aren't commensurable.** A recurrence group's 820 and a header mark's 196 measure entirely different things. A global sort therefore lets one noisy family silently evict the rest — the general form of every logo bug we've hit.

## What

- **Quota the pool per signal family** (`structured` / `dom` / `recurrence`) instead of a global score sort. Coverage is the pool's only job; the downstream vision step does the discriminating by looking at the rendered candidates. Scores now only pre-rank *within* a family.
- **Collect the publisher-declared signals** that make this tractable: `og:image`, `twitter:image`, `msapplication-TileImage`, and web-app-manifest icons (fetched Python-side, since the probe is synchronous). apple.com serves its real mark at `og:image` as `open_graph_logo.png`.
- **Restrict schema.org `image`** to Organization-ish nodes, so a `Product` or `Article` hero can't pose as the logo.
- Dedupe recurrence groups against homepage candidates by URL (the "TV & Home" glyph previously occupied two slots).

Research backing the direction: logo object-detection (YOLO/LogoDet-3K) is closed-set and does not generalize to arbitrary brands, so heuristic scoring and ML detection are both dead ends here. Every OSS extractor (`metascraper`, `brandr-api`, `logo-scrape`) does multi-source discovery + scoring; vision-as-arbiter is strictly better, provided the pool has coverage.

## Verification

8 live scrapes at the **production page count (8)**, the exact config that broke before:

| Site | Pool | Result |
|---|---|---|
| apple.com | `structured=2, dom=5, recurrence=3` | ✅ real Apple mark |
| stripe.com | `structured=3, dom=5, recurrence=1` | ✅ |
| notion.com | `structured=3, dom=5, recurrence=0` | ✅ |
| linear.app | `structured=3, dom=5, recurrence=1` | ✅ |
| allbirds.com | `structured=2, dom=5, recurrence=0` | ✅ |
| pizzeriabianco.com | `structured=2, dom=5, recurrence=0` | ✅ |
| bendbrewingco.com | `structured=2, dom=0, recurrence=2` | ✅ (recurrence-only find) |
| westhillsvineyards.com | `structured=1, dom=5, recurrence=0` | ✅ horse emblem |

**8/8 correct**, all vision-picked, none reaching the fallback chain. Picks stable across two independent runs.

Companion PR in dialogue-foundry renders the new candidates for vision and trims logo padding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
