### PR TITLE
fix(crawler): stop discarding .html pages as file URLs

### DIFF
--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -796,22 +796,42 @@ def should_exclude_path(url, excluded_paths):
     return False
 
 
+# Extensions that are genuinely downloadable assets rather than crawlable pages.
+# Anything else is followed — crucially including .html/.php/.aspx, which ARE
+# pages. Treating every dotted path as a file meant a site whose links end in
+# .html (e.g. /dinner/index.html) had its entire link graph discarded and only
+# the start URL was ever indexed.
+NON_PAGE_EXTENSIONS = frozenset(
+    [
+        # images
+        "jpg", "jpeg", "png", "gif", "svg", "webp", "ico", "bmp", "tiff", "avif",
+        # documents
+        "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx", "csv",
+        # archives / binaries
+        "zip", "gz", "tar", "rar", "7z", "dmg", "exe", "pkg",
+        # media
+        "mp3", "mp4", "avi", "mov", "wmv", "webm", "wav", "ogg", "m4a",
+        # assets / feeds
+        "css", "js", "json", "xml", "rss", "woff", "woff2", "ttf", "eot",
+    ]
+)
+
+
 def is_file_url(url):
-    """Check if a URL points to a file (has a file extension).
+    """Check if a URL points to a non-page asset that shouldn't be crawled.
 
     Args:
         url (str): The URL to check
 
     Returns:
-        bool: True if the URL points to a file, False otherwise
+        bool: True if the URL points to a downloadable asset, False if it's a
+              page worth crawling (including extensionless and .html URLs).
     """
-    # Parse the URL and extract the path
-    parsed_url = urlparse(url)
-    path = parsed_url.path.lower()
+    path = urlparse(url).path.lower()
+    if "." not in path:
+        return False
 
-    # Check if the path contains a dot followed by letters/numbers
-    # This indicates a file extension
-    return "." in path and any(c.isalnum() for c in path.split(".")[-1])
+    return path.rpartition(".")[2] in NON_PAGE_EXTENSIONS
 
 
 def is_valid_web_url(url):


### PR DESCRIPTION
## Problem

`is_file_url()` treated **any** URL whose path contained a dot as a downloadable file:

```python
return "." in path and any(c.isalnum() for c in path.split(".")[-1])
```

So `/dinner/index.html` was classified a "file" and dropped from the crawl, exactly like `/logo.png` would be. Link discovery found the pages fine — this filter deleted them immediately afterwards.

Sites with extensionless "pretty" URLs crawled normally, which is why this went unnoticed. Sites whose links end in `.html`, `.php`, or `.aspx` had their **entire link graph discarded** and only the start URL was ever indexed.

### How it surfaced

A prospect's demo (Café Renaissance) landed **3 chunks in Upstash for the whole site**. Their only two internal links are `/dinner/index.html` and `/entrées/index.html` — both rejected. The RAG namespace contained nothing but the 1,123-character homepage, so the chatbot could recite the tea *schedule* (on the homepage) but knew nothing about the menus. The prospect asked it a menu question and it deflected them to the restaurant's phone number.

Depth was not the cause — the crawl runs at depth 1, which reaches both pages.

## Fix

Check an explicit set of non-page asset extensions (images, documents, archives, media, css/js/feeds) rather than "has a dot." Real pages are followed; only genuine assets are skipped.

## Verification

`is_file_url` behaviour:

| URL | before | after |
|---|---|---|
| `/dinner/index.html` | skipped | **crawled** |
| `/entr%c3%a9es/index.html` | skipped | **crawled** |
| `/menu.php`, `/about.aspx` | skipped | **crawled** |
| `/menu` (extensionless) | crawled | crawled |
| `/logo.png`, `/menu.pdf`, `/app.js`, `/sitemap.xml` | skipped | skipped |

End-to-end: re-ran `orchestrator.py` against `caferenaissance.com` into the live demo namespace. It now crawls the homepage **and both menu pages** — 3 stale records deleted, 6 upserted. Asking the deployed demo chatbot about entrées now returns real dishes and prices (`Filet de flétan — $42`, `Coquilles Saint-Jacques — $38`), where it previously knew nothing.

## Note

The recrawl also showed `/dinner` and `/dinner/index.html` being indexed as two separate records for the same page — `normalize_url` doesn't collapse directory vs `index.html` URLs. Harmless but wasteful (6 records for 3 unique pages). Left alone here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)