### PR TITLE
fix(crawler): stop indexing bot-challenge pages; add residential proxy + media blocking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ EXCLUDED_TAGS=footer,nav,header
 # PROXY_SERVER=http://gate.provider.com:7000
 # PROXY_USERNAME=your_proxy_username
 # PROXY_PASSWORD=your_proxy_password
+# Block image/media/font downloads during the deep crawl (default true) — the
+# RAG index only needs text, and this is the main lever on per-GB proxy cost.
+# Set false only if a site hides text content behind media.
+# BLOCK_MEDIA=true
 
 # LLM Settings
 # OpenAI model provider to use

--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,15 @@ BATCH_SIZE=10
 # Comma-separated list of HTML tags to exclude from processing
 EXCLUDED_TAGS=footer,nav,header
 
+# Anti-bot proxy (optional). Leave PROXY_SERVER empty to crawl directly.
+# Some sites (e.g. WooCommerce/WAF bot walls) block datacenter IPs like
+# Render's regardless of browser fingerprint — route through a residential/
+# rotating proxy so the crawl comes from a real-looking IP. The crawler logs
+# the outbound IP (through the proxy) at startup so you can confirm it works.
+# PROXY_SERVER=http://gate.provider.com:7000
+# PROXY_USERNAME=your_proxy_username
+# PROXY_PASSWORD=your_proxy_password
+
 # LLM Settings
 # OpenAI model provider to use
 LLM_PROVIDER=openai/gpt-4o-mini

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -130,6 +130,15 @@ class CrawlerConfig:
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
     )
+    # Outbound proxy. The browser fingerprint is already heavily disguised
+    # (magic / simulate_user / override_navigator / real UA), so the remaining
+    # tell is IP reputation: crawling from a datacenter IP (e.g. Render) gets
+    # flagged by WooCommerce/WAF bot walls no matter how convincing the browser
+    # looks. Point PROXY_SERVER at a residential/rotating proxy to crawl from a
+    # real-looking IP. Empty (default) = direct connection, no proxy.
+    proxy_server: str = ""
+    proxy_username: str = ""
+    proxy_password: str = ""
 
     # Output directories
     output_dir: str = "cleaned_output"
@@ -286,6 +295,15 @@ class CrawlerConfig:
 
         if "USER_AGENT" in os.environ:
             config.user_agent = os.environ["USER_AGENT"]
+
+        if "PROXY_SERVER" in os.environ:
+            config.proxy_server = os.environ["PROXY_SERVER"]
+
+        if "PROXY_USERNAME" in os.environ:
+            config.proxy_username = os.environ["PROXY_USERNAME"]
+
+        if "PROXY_PASSWORD" in os.environ:
+            config.proxy_password = os.environ["PROXY_PASSWORD"]
 
         if "HEADLESS" in os.environ:
             config.headless = os.environ["HEADLESS"].lower() in ["true", "1", "yes"]

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -139,6 +139,13 @@ class CrawlerConfig:
     proxy_server: str = ""
     proxy_username: str = ""
     proxy_password: str = ""
+    # Block image/media/font network requests during the deep crawl. The RAG
+    # index only needs text, and rendered product pages pull megabytes of
+    # images — the dominant cost on a per-GB residential proxy. Blocking them
+    # at the network level cuts bandwidth ~5-10x. (Only the deep crawl; the
+    # shallow brand scrape needs images for logo detection, so it never sets
+    # this.) Disable via BLOCK_MEDIA=false if a site hides text behind media.
+    block_media: bool = True
 
     # Output directories
     output_dir: str = "cleaned_output"
@@ -304,6 +311,13 @@ class CrawlerConfig:
 
         if "PROXY_PASSWORD" in os.environ:
             config.proxy_password = os.environ["PROXY_PASSWORD"]
+
+        if "BLOCK_MEDIA" in os.environ:
+            config.block_media = os.environ["BLOCK_MEDIA"].lower() in [
+                "true",
+                "1",
+                "yes",
+            ]
 
         if "HEADLESS" in os.environ:
             config.headless = os.environ["HEADLESS"].lower() in ["true", "1", "yes"]

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -18,6 +18,40 @@ from crawler.config import CrawlerConfig
 from crawler.custom_markdown import create_custom_markdown_generator
 
 
+def build_proxy_config(config):
+    """Build a crawl4ai proxy_config dict from CrawlerConfig, or None.
+
+    Returns None when no PROXY_SERVER is set so the crawler connects directly.
+    Username/password are attached only when provided (open proxies need none).
+    """
+    if not getattr(config, "proxy_server", ""):
+        return None
+    proxy = {"server": config.proxy_server}
+    if getattr(config, "proxy_username", ""):
+        proxy["username"] = config.proxy_username
+    if getattr(config, "proxy_password", ""):
+        proxy["password"] = config.proxy_password
+    return proxy
+
+
+def _proxy_url(config):
+    """Build a requests-style proxy URL (auth embedded) for the IP probe.
+
+    crawl4ai takes server/username/password as separate fields, but the
+    ``requests`` library wants them inside the URL: scheme://user:pass@host:port.
+    """
+    server = config.proxy_server
+    scheme, sep, rest = server.partition("://")
+    if not sep:  # no scheme in the server string; default to http
+        scheme, rest = "http", server
+    user = getattr(config, "proxy_username", "")
+    pwd = getattr(config, "proxy_password", "")
+    if user:
+        auth = f"{user}:{pwd}@" if pwd else f"{user}@"
+        return f"{scheme}://{auth}{rest}"
+    return f"{scheme}://{rest}"
+
+
 async def crawl(config: CrawlerConfig = None):
     """
     Crawl websites based on provided configuration, process content,
@@ -144,6 +178,7 @@ async def crawl(config: CrawlerConfig = None):
     unique_links = set()
     all_results = []
 
+    proxy_config = build_proxy_config(config)
     browser_config = BrowserConfig(
         browser_type=config.browser_type,
         chrome_channel=config.browser_channel,
@@ -153,6 +188,7 @@ async def crawl(config: CrawlerConfig = None):
         text_mode=config.text_mode,
         ignore_https_errors=config.ignore_https_errors,
         user_agent=config.user_agent,
+        proxy_config=proxy_config,
     )
     # crawl4ai 0.6.x defaults chrome_channel="chromium" which Playwright
     # treats as a channel lookup and falls back to system Chrome. Clear it
@@ -161,14 +197,29 @@ async def crawl(config: CrawlerConfig = None):
 
     start_urls = config.start_urls
 
-    # Check outbound IP address for debugging
+    # Check outbound IP address for debugging. When a proxy is configured,
+    # route this probe through it too, so the logged IP is the one the target
+    # site actually sees — a direct probe would report the datacenter IP even
+    # though the browser is proxied, which is misleading.
+    if proxy_config:
+        print(f"🛡️  Proxy enabled: {proxy_config['server']}")
+        ip_probe_proxies = {"http": _proxy_url(config), "https": _proxy_url(config)}
+    else:
+        print("🛡️  No proxy configured — crawling from the direct outbound IP.")
+        ip_probe_proxies = None
     try:
-        ip_response = requests.get('https://api.ipify.org?format=json', timeout=5)
+        ip_response = requests.get(
+            'https://api.ipify.org?format=json', timeout=10, proxies=ip_probe_proxies
+        )
         current_ip = ip_response.json().get('ip', 'Unknown')
-        print(f"🌐 Current outbound IP address: {current_ip}")
+        label = "outbound IP via proxy" if proxy_config else "Current outbound IP address"
+        print(f"🌐 {label}: {current_ip}")
         print(f"   Make sure this IP is whitelisted on the target site!")
     except Exception as e:
         print(f"⚠️  Could not determine outbound IP: {e}")
+        if proxy_config:
+            print(f"   ⚠️  Proxy probe failed — the proxy may be down or "
+                  f"misconfigured; the crawl will likely still be blocked.")
 
     async with AsyncWebCrawler(config=browser_config) as crawler:
         # If no specific start URLs are provided, use a default

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -52,6 +52,85 @@ def _proxy_url(config):
     return f"{scheme}://{rest}"
 
 
+# Resource types worth blocking on a text-only crawl. Images/media are the bulk
+# of a rendered ecommerce page's bytes; fonts are pure decoration for our
+# purposes. Stylesheets/scripts are kept — some sites need JS to render content
+# and to clear the anti-bot challenge.
+_BLOCKED_RESOURCE_TYPES = {"image", "media", "font"}
+
+
+class _BandwidthTracker:
+    """Accumulates approximate over-the-wire bytes so a crawl can report what it
+    will cost on a per-GB residential proxy. Counts Content-Length on responses
+    that were actually fetched; blocked requests never produce a response, so
+    they correctly contribute zero."""
+
+    def __init__(self):
+        self.total_bytes = 0
+        self.blocked_requests = 0
+
+    def make_context_hook(self, block_media):
+        async def on_page_context_created(context, page=None, **kwargs):
+            if block_media:
+                async def _route(route):
+                    try:
+                        if route.request.resource_type in _BLOCKED_RESOURCE_TYPES:
+                            self.blocked_requests += 1
+                            await route.abort()
+                        else:
+                            await route.continue_()
+                    except Exception:
+                        # Never let a routing error abort the whole page.
+                        try:
+                            await route.continue_()
+                        except Exception:
+                            pass
+
+                await context.route("**/*", _route)
+
+            def _on_response(response):
+                try:
+                    cl = response.headers.get("content-length")
+                    if cl and cl.isdigit():
+                        self.total_bytes += int(cl)
+                except Exception:
+                    pass
+
+            if page is not None:
+                page.on("response", _on_response)
+
+        return on_page_context_created
+
+    def report(self, page_count):
+        """Print a bandwidth + projected-cost summary for the run."""
+        mb = self.total_bytes / (1024 * 1024)
+        print("\n📊 Bandwidth this crawl:")
+        print(
+            f"   {mb:.1f} MB across {page_count} page(s)"
+            + (f", {self.blocked_requests} image/media/font requests blocked"
+               if self.blocked_requests else "")
+        )
+        if page_count > 0:
+            per_page_kb = (self.total_bytes / page_count) / 1024
+            print(f"   ~{per_page_kb:.0f} KB/page")
+        # Project a weekly (x4/month) cadence across common residential price
+        # points so the operator can pick a plan. content-length misses chunked
+        # responses, so treat this as a floor, not an exact bill.
+        monthly_gb = (self.total_bytes * 4) / (1024 ** 3)
+        print(
+            f"   Projected monthly (weekly re-crawl, ~this size): "
+            f"{monthly_gb:.2f} GB"
+        )
+        for label, price in (("PacketStream ~$1/GB", 1.0),
+                             ("IPRoyal ~$3.5/GB", 3.5),
+                             ("IPRoyal entry ~$7/GB", 7.0)):
+            print(f"     {label}: ~${monthly_gb * price:.2f}/mo")
+        print(
+            "   (Content-Length only — chunked responses aren't counted, so "
+            "real usage runs somewhat higher.)\n"
+        )
+
+
 async def crawl(config: CrawlerConfig = None):
     """
     Crawl websites based on provided configuration, process content,
@@ -221,7 +300,19 @@ async def crawl(config: CrawlerConfig = None):
             print(f"   ⚠️  Proxy probe failed — the proxy may be down or "
                   f"misconfigured; the crawl will likely still be blocked.")
 
+    bandwidth = _BandwidthTracker()
+
     async with AsyncWebCrawler(config=browser_config) as crawler:
+        # Block image/media/font requests (bandwidth) and tally response bytes
+        # so the crawl can report its per-GB proxy cost. Set on the strategy
+        # after the crawler exists; the hook fires for every page context.
+        crawler.crawler_strategy.set_hook(
+            "on_page_context_created",
+            bandwidth.make_context_hook(config.block_media),
+        )
+        if config.block_media:
+            print("🪶 Media blocking ON — images/media/fonts won't be downloaded.")
+
         # If no specific start URLs are provided, use a default
         if not config.start_urls:
             raise ValueError("No start URLs provided in configuration")
@@ -463,6 +554,8 @@ async def crawl(config: CrawlerConfig = None):
             continue
 
     print(f"✅ Crawling complete! Processed {len(final_results)} unique pages")
+
+    bandwidth.report(len(final_results))
 
     return final_results  # Return the processed results
 

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -315,11 +315,27 @@ async def crawl(config: CrawlerConfig = None):
     # page with a 403/202 after the JS challenge clears — keep those, but still
     # reject genuine block/challenge pages.
     valid_pages = []
+    dropped_block_urls = []
     for res in all_results:
         status = getattr(res, "status_code", None)
         if status is None:
             continue
         if 200 <= status <= 301:
+            # Bot walls often serve their challenge page with a 200 (seen on
+            # gefonline-sales.com), so a passing status alone doesn't mean the
+            # content is real — without this check the interstitial would get
+            # chunked and embedded as if it were the page. Require both
+            # signals (challenge phrase + small body) before dropping, so a
+            # real page that merely mentions a marker phrase is spared.
+            html = getattr(res, "html", "") or ""
+            if is_block_page(html) and len(html) < MIN_REAL_CONTENT_BYTES:
+                url = getattr(res, "url", "?")
+                dropped_block_urls.append(url)
+                print(
+                    f"🚫 Dropping challenge/block page served with status "
+                    f"{status}: {url} ({len(html)} bytes)"
+                )
+                continue
             valid_pages.append(res)
         elif has_real_content(res):
             print(
@@ -327,6 +343,15 @@ async def crawl(config: CrawlerConfig = None):
                 f"real content detected (anti-bot WAF likely)"
             )
             valid_pages.append(res)
+    if dropped_block_urls:
+        print(
+            f"\n🚫 {len(dropped_block_urls)} page(s) were bot-challenge "
+            f"interstitials and were NOT indexed. The crawler is being "
+            f"blocked on these URLs:"
+        )
+        for url in dropped_block_urls:
+            print(f"   {url}")
+        print()
     print(f"Debug: After status filtering: {len(valid_pages)} valid pages")
 
     print("Post-processing results to remove links...")
@@ -401,6 +426,13 @@ BLOCK_PAGE_MARKERS = [
     "access denied",
     "you have been blocked",
     "ddos protection",
+    "verify you are human",
+    # Challenge walls that come back with a 200 status (seen on
+    # gefonline-sales.com): the page IS the interstitial, so these phrases
+    # never appear as incidental script references on a real page.
+    "you might be a robot",
+    "prove you're a human",
+    "complete the captcha",
 ]
 
 # Minimum HTML size for a non-2xx page to be treated as real content rather
@@ -450,18 +482,11 @@ def check_captcha_indicators(result, url):
     # actual blocks). We only warn on a real block *symptom*:
     #
     #   1. a challenge-wall phrase — copy that only renders when the page IS the
-    #      interstitial, never as an incidental script reference, or
+    #      interstitial, never as an incidental script reference (the shared
+    #      BLOCK_PAGE_MARKERS list, same one the status filter drops on), or
     #   2. a blocking HTTP status (403/429/503), or
     #   3. a suspiciously empty body on a 200 (the classic stripped block page).
-    block_phrases = [
-        "verify you are human",
-        "checking your browser",
-        "just a moment",
-        "ddos protection",
-        "access denied",
-        "attention required",  # Cloudflare block-page title
-    ]
-    found_phrases = [p for p in block_phrases if p in html_lower]
+    found_phrases = [p for p in BLOCK_PAGE_MARKERS if p in html_lower]
     is_error_status = status_code in (403, 429, 503)
     is_tiny = len(html) < 5000 and status_code == 200
 

--- a/scrape_page.py
+++ b/scrape_page.py
@@ -160,6 +160,8 @@ def _select_links(root_result, start_url: str, limit: int) -> list:
 
 
 def _build_browser_config(config: CrawlerConfig) -> BrowserConfig:
+    from crawler.crawl import build_proxy_config
+
     browser_config = BrowserConfig(
         browser_type=config.browser_type,
         chrome_channel=config.browser_channel,
@@ -169,6 +171,9 @@ def _build_browser_config(config: CrawlerConfig) -> BrowserConfig:
         text_mode=config.text_mode,
         ignore_https_errors=config.ignore_https_errors,
         user_agent=config.user_agent,
+        # Same IP-reputation reasoning as the deep crawl — route the shallow
+        # brand/demo scrape through the proxy when one is configured.
+        proxy_config=build_proxy_config(config),
         # crawl4ai's default (1080x600) is barely taller than a nav bar — most
         # homepages render their real UI chrome (buttons, footer) below that,
         # and a short viewport also under-triggers scroll-based lazy loading.


### PR DESCRIPTION
## Summary

Fixes the crawler poisoning RAG namespaces with bot-challenge pages, and adds the pieces needed to actually get past aggressive bot walls (residential proxy) cheaply (media blocking + cost reporting). Motivated by `gefonline-sales.com`, whose product pages were being served to the crawler as a "prove you're a robot" captcha at HTTP 200 — that block page was getting chunked and embedded as if it were product content, so F-code lookups returned nothing.

## Commits

**1. Drop bot-challenge pages served with a 200 status**
Block/challenge interstitials were only rejected on non-2xx statuses; a wall that returns its captcha page with a 200 sailed through the status filter and got indexed. Now a 2xx page is dropped when it matches `BLOCK_PAGE_MARKERS` **and** is under `MIN_REAL_CONTENT_BYTES` (both signals required, so a real page that merely mentions a marker phrase is spared). Each dropped URL logs, plus a loud end-of-crawl summary so being blocked surfaces as a problem instead of silently indexing garbage. Added the 200-status challenge phrases the WooCommerce wall renders, and pointed `check_captcha_indicators` at the shared marker list.

**2. Optional residential-proxy support**
The browser fingerprint is already heavily disguised (magic/simulate_user/override_navigator/real UA/stealth), so the remaining tell on sites that still block is IP reputation — datacenter IPs (Render) get flagged regardless. Adds `PROXY_SERVER`/`PROXY_USERNAME`/`PROXY_PASSWORD`, wired into `BrowserConfig.proxy_config` for both the deep crawl and the shallow scrape. Empty = direct connection (unchanged default). The startup outbound-IP probe routes through the proxy when set, so the logged IP is what the target sees; warns loudly if the proxy probe fails.

**3. Block media on the deep crawl + report bandwidth/cost**
On a per-GB residential proxy, rendered ecommerce pages cost mostly for images the RAG index never uses. Blocks `image`/`media`/`font` at the network level (`BLOCK_MEDIA=true` default) via a Playwright route hook — ~5-10x less bandwidth without touching the anti-bot fingerprint the way `text_mode` would. Also tallies response `Content-Length` and prints an end-of-crawl bandwidth summary with projected monthly cost at a weekly cadence across common price points. Deep crawl only — the shallow brand scrape needs images for logo detection.

## Validation

- Block-page detection unit-tested against the actual gefonline challenge copy (dropped) plus false-positive guards: real page loading invisible reCAPTCHA (kept), a 32KB page with an incidental marker phrase (kept), Cloudflare interstitial (dropped).
- Proxy verified end-to-end through ScraperAPI residential: gefonline product page returned real content (192KB, HTTP 200, F-code `F003443`, schema.org ItemPage) instead of the captcha — IP alone clears the wall, no JS-render needed.
- Media-block hook + bandwidth tally unit-tested (image/media/font aborted; document/script/css/xhr continued; Content-Length summed).
- Projected cost from a realistic page size: ~1,000 pages weekly ≈ 0.73 GB/mo ≈ ~$5/mo at IPRoyal's entry rate.

## Notes

- No behavior change unless `PROXY_SERVER` is set; `BLOCK_MEDIA` defaults on but affects only the deep RAG crawl.
- Getting past a given wall still depends on the proxy provider's IP quality — the block-page drop + startup logs make a failed bypass obvious rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
