### PR TITLE
fix(crawler): repair media-block hook, proxy config, and 403-wall detection

### DIFF
--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import sys
 import requests
 from urllib.parse import urlparse, urlunparse
@@ -11,6 +12,7 @@ from crawl4ai import (
     LLMConfig,
     DefaultMarkdownGenerator,
 )
+from crawl4ai.async_configs import ProxyConfig
 from crawl4ai.deep_crawling import BFSDeepCrawlStrategy
 from crawler.sanitize_filename import sanitize_filename
 from crawler.clean_markdown import process_markdown_results
@@ -19,19 +21,25 @@ from crawler.custom_markdown import create_custom_markdown_generator
 
 
 def build_proxy_config(config):
-    """Build a crawl4ai proxy_config dict from CrawlerConfig, or None.
+    """Build a crawl4ai ProxyConfig from CrawlerConfig, or None.
 
     Returns None when no PROXY_SERVER is set so the crawler connects directly.
     Username/password are attached only when provided (open proxies need none).
+
+    Must be a ProxyConfig object, NOT a dict: BrowserConfig accepts a dict
+    without complaint but stores it as-is, and browser_manager then reads
+    ``proxy_config.username`` — attribute access a dict can't answer. The
+    AttributeError surfaces as a browser that never launches, i.e. every page
+    coming back with status None and no HTML, which reads like a bot block
+    rather than a config bug.
     """
     if not getattr(config, "proxy_server", ""):
         return None
-    proxy = {"server": config.proxy_server}
-    if getattr(config, "proxy_username", ""):
-        proxy["username"] = config.proxy_username
-    if getattr(config, "proxy_password", ""):
-        proxy["password"] = config.proxy_password
-    return proxy
+    return ProxyConfig(
+        server=config.proxy_server,
+        username=getattr(config, "proxy_username", "") or None,
+        password=getattr(config, "proxy_password", "") or None,
+    )
 
 
 def _proxy_url(config):
@@ -70,8 +78,14 @@ class _BandwidthTracker:
         self.blocked_requests = 0
 
     def make_context_hook(self, block_media):
-        async def on_page_context_created(context, page=None, **kwargs):
-            if block_media:
+        # crawl4ai invokes this as hook(page, context=context, config=config) —
+        # page positional, context by keyword. Naming the first parameter
+        # anything but `page` makes Python bind the positional page to it and
+        # then collide with the context keyword ("got multiple values for
+        # argument 'context'"). execute_hook doesn't catch that, so the page
+        # context dies and every URL comes back with status None and no HTML.
+        async def on_page_context_created(page, context=None, **kwargs):
+            if block_media and context is not None:
                 async def _route(route):
                     try:
                         if route.request.resource_type in _BLOCKED_RESOURCE_TYPES:
@@ -281,7 +295,7 @@ async def crawl(config: CrawlerConfig = None):
     # site actually sees — a direct probe would report the datacenter IP even
     # though the browser is proxied, which is misleading.
     if proxy_config:
-        print(f"🛡️  Proxy enabled: {proxy_config['server']}")
+        print(f"🛡️  Proxy enabled: {proxy_config.server}")
         ip_probe_proxies = {"http": _proxy_url(config), "https": _proxy_url(config)}
     else:
         print("🛡️  No proxy configured — crawling from the direct outbound IP.")
@@ -470,7 +484,7 @@ async def crawl(config: CrawlerConfig = None):
             # signals (challenge phrase + small body) before dropping, so a
             # real page that merely mentions a marker phrase is spared.
             html = getattr(res, "html", "") or ""
-            if is_block_page(html) and len(html) < MIN_REAL_CONTENT_BYTES:
+            if is_block_page(html) and visible_text_length(html) < MIN_REAL_TEXT_CHARS:
                 url = getattr(res, "url", "?")
                 dropped_block_urls.append(url)
                 print(
@@ -577,12 +591,30 @@ BLOCK_PAGE_MARKERS = [
     "you might be a robot",
     "prove you're a human",
     "complete the captcha",
+    "403 - forbidden",
 ]
 
-# Minimum HTML size for a non-2xx page to be treated as real content rather
-# than a block page. The SiteGround challenge screen is ~12KB; real pages are
-# much larger.
-MIN_REAL_CONTENT_BYTES = 20000
+# Minimum amount of human-readable text for a page to count as real content.
+# Deliberately measured on text, not raw HTML: a WAF block page can be huge and
+# still say nothing. SiteGround's 403 wall is ~80KB of inline CSS and decorative
+# SVG wrapped around 65 characters ("Access to this page is forbidden.") — a
+# raw-byte threshold waves it straight through into the index.
+MIN_REAL_TEXT_CHARS = 500
+
+_NON_TEXT_TAGS_RE = re.compile(r"(?is)<(script|style|svg|noscript|template)\b.*?</\1>")
+_HTML_COMMENT_RE = re.compile(r"(?s)<!--.*?-->")
+_HTML_TAG_RE = re.compile(r"(?s)<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def visible_text_length(html):
+    """Length of the human-readable text in ``html``, ignoring markup and assets."""
+    if not html:
+        return 0
+    text = _NON_TEXT_TAGS_RE.sub(" ", html)
+    text = _HTML_COMMENT_RE.sub(" ", text)
+    text = _HTML_TAG_RE.sub(" ", text)
+    return len(_WHITESPACE_RE.sub(" ", text).strip())
 
 
 def is_block_page(html):
@@ -598,7 +630,7 @@ def has_real_content(result):
     (e.g. 403/202) after a JS challenge has cleared.
     """
     html = getattr(result, "html", "") or ""
-    return len(html) >= MIN_REAL_CONTENT_BYTES and not is_block_page(html)
+    return visible_text_length(html) >= MIN_REAL_TEXT_CHARS and not is_block_page(html)
 
 
 def check_captcha_indicators(result, url):
@@ -611,11 +643,17 @@ def check_captcha_indicators(result, url):
     """
     html = result.html if hasattr(result, 'html') and result.html else ""
     status_code = getattr(result, 'status_code', None)
-    
+
     if not html:
+        # crawl4ai swallows launch/navigation exceptions into a failed result,
+        # so error_message is the only place a browser-level fault (bad proxy,
+        # DNS, TLS) is visible — without it every such fault looks like a block.
+        error = getattr(result, 'error_message', None)
         print(f"⚠️  No HTML content for {url} (Status: {status_code})")
+        if error:
+            print(f"   ↳ crawl4ai error: {error}")
         return
-    
+
     html_lower = html.lower()
 
     # A page that merely *references* a captcha library is not blocked. Modern


### PR DESCRIPTION
## Summary

Found while debugging why the NSI crawl returned **zero pages**, every URL reporting `Status: None`. Three separate bugs, none of which were the bot wall we thought we were fighting.

### 1. The media-block hook never ran (this is what broke the crawl)

crawl4ai invokes the hook as `hook(page, context=context, config=config)` — `page` positional, `context` by keyword. Our first parameter was *named* `context`, so Python bound the positional `page` to it and then collided with the keyword:

```
TypeError: on_page_context_created() got multiple values for argument 'context'
```

`execute_hook` has no try/except (`return await hook(*args, **kwargs)`), so the exception killed page-context creation and every fetch came back empty. Reproduced exactly against crawl4ai 0.7.8 and verified fixed.

Two consequences worth calling out: **media blocking has never blocked a single request**, and **the bandwidth/cost report has always printed 0 bytes** — the numbers we sized the proxy budget on were not real.

### 2. `build_proxy_config` returned a dict

`BrowserConfig` accepts a dict without complaint but stores it as-is; `browser_manager` then reads `proxy_config.username`, which a dict can't answer. 0.7.x happens to coerce dicts, but **0.6.x (this repo's pin) does not** — the browser simply fails to launch. Now returns a `ProxyConfig`, correct on both.

### 3. `has_real_content` would have indexed an 80KB "403 Forbidden" wall

It sized pages by **raw HTML bytes**. SiteGround's 403 wall is ~80KB of inline CSS and decorative SVG wrapped around **65 characters** of text — 4× the old 20KB "this is real" threshold, so it sailed through. That's the original captcha-indexing bug in a new costume.

Now measures human-readable text (the thing we actually index):

| page | raw bytes | visible text | verdict |
|---|---|---|---|
| SiteGround 403 wall | 80,671 | **65 chars** | 🚫 dropped |
| real product page | 192,401 | **4,002 chars** | ✅ kept |

Also prints crawl4ai's `error_message` when a page comes back empty — its absence is why (1) masqueraded as a bot block for as long as it did.

## Context: the bot wall was a User-Agent check all along

Same IP, same second, **no proxy**:

| User-Agent | Result |
|---|---|
| Chrome 131/148 (our default) | **403 Forbidden** |
| `UntapAI-Crawler` | 200 — real page, F-code `F003443` |
| `curl/8.7.1` | 200 — real page |
| Googlebot | 200 — real page |

Headless Chromium with `UntapAI-Crawler` pulls the full 270KB product page with no proxy. The site blocks clients that claim to be Chrome but don't behave like it. Residential proxies were never necessary.

The proxy support stays in (it's opt-in, off by default, and now actually correct), but NSI will set `USER_AGENT=UntapAI-Crawler` and run without one.

## Test plan

- [x] Reproduced the `got multiple values for argument 'context'` failure on crawl4ai 0.7.8 (Render's version) and confirmed the fix restores fetching (`success: True`, media requests actually blocked)
- [x] Confirmed dict-vs-`ProxyConfig` behaviour on both 0.6.3 and 0.7.8
- [x] Verified block detection against real captured pages (table above)
- [x] `py_compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)