### PR TITLE
fix(crawler): make max_pages unlimited by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ UPSTASH_NAMESPACE=your_namespace_here
 START_URLS=https://example.com/page1,https://example.com/page2
 # Maximum crawl depth (0 means only starting URLs)
 MAX_DEPTH=2
+# Hard ceiling on pages indexed. Unlimited when unset — a cap silently
+# truncates the index, and a half-indexed catalog answers "not found" for
+# anything past the cutoff. Set this only to bound a site too big to index whole.
+# MAX_PAGES=500
 # Number of URLs to process in each batch
 BATCH_SIZE=10
 # Comma-separated list of HTML tags to exclude from processing

--- a/crawler/config.py
+++ b/crawler/config.py
@@ -23,9 +23,13 @@ class CrawlerConfig:
     # Crawling parameters
     start_urls: List[str] = field(default_factory=list)
     max_depth: int = 3
-    # Hard ceiling on pages visited by the deep crawl. max_depth alone is not a
-    # bound — depth 1 on a site with a 400-link footer is a 400-page crawl.
-    max_pages: int = 100
+    # Optional ceiling on pages visited by the deep crawl. Unlimited by default:
+    # a cap silently truncates the index, and a half-indexed catalog answers
+    # "not found" for anything past the cutoff, which is indistinguishable from
+    # a crawl failure. Set MAX_PAGES to bound a site that's too big to index
+    # whole. (max_depth alone is not a bound — depth 1 on a site with a 400-link
+    # footer is a 400-page crawl.)
+    max_pages: float = float("inf")
     # Concurrent subpage fetches within one shared browser (all batches reuse
     # the same AsyncWebCrawler). Bottleneck per page is mostly LLM/network
     # wait, not local CPU, so this can run higher than it looks.

--- a/crawler/crawl.py
+++ b/crawler/crawl.py
@@ -418,12 +418,13 @@ async def crawl(config: CrawlerConfig = None):
         # even though that phase itself was correctly bounded to max_pages.
         # Cap here too so content-fetch work stays within the same budget.
         batch_size = config.batch_size
-        url_list = list(unique_links)[: config.max_pages]
-        if len(unique_links) > config.max_pages:
+        url_list = list(unique_links)
+        if len(url_list) > config.max_pages:
             print(
                 f"Capping content crawl to {config.max_pages} of "
-                f"{len(unique_links)} unique links found (MAX_PAGES)"
+                f"{len(url_list)} unique links found (MAX_PAGES)"
             )
+            url_list = url_list[: int(config.max_pages)]
         total_batches = (len(url_list) + batch_size - 1) // batch_size
 
         print(f"Processing URLs in {total_batches} batches of {batch_size}")


### PR DESCRIPTION
## Summary

`max_pages` defaulted to **100**, silently truncating the index.

NSI's site is **341 URLs** (305 of them products, per its sitemap), so roughly **two thirds of the catalog was never crawled**. A half-indexed catalog answers "not found" for anything past the cutoff — which is indistinguishable from a crawl failure or a broken metadata filter. That's a large part of why an F-code lookup (`f35204`) came back empty, and it sent us chasing a bot wall for a query that simply had no document behind it.

crawl4ai's own BFS default is already unlimited (`from math import inf as infinity`) — the 100-page cap was **ours**. This matches it, and keeps `MAX_PAGES` as an explicit opt-in bound for sites too big to index whole.

## Changes

- `crawler/config.py` — `max_pages: float = float("inf")` (was `int = 100`)
- `crawler/crawl.py` — guard the content-fetch slice: `list[:float('inf')]` raises `TypeError`, so only slice when a real cap is set
- `.env.example` — document `MAX_PAGES` as an opt-in ceiling

## Cost note

Unlimited means a genuinely large customer site will now crawl and summarize every page, so OpenAI spend scales with site size. `MAX_PAGES` is the lever if that ever bites. Worth knowing rather than discovering.

demo-setup is unaffected — it passes `MAX_PAGES` explicitly (100), which is the right call for throwaway demo pages built during a sales call.

## Test plan

- [x] Default is `inf`; 341 links all survive the content-fetch path (no truncation, no `TypeError`)
- [x] `MAX_PAGES=<n>` still caps correctly
- [x] `py_compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
